### PR TITLE
Appending firestore command to include the data for update

### DIFF
--- a/src/buildFirestoreCommand.js
+++ b/src/buildFirestoreCommand.js
@@ -45,7 +45,9 @@ export default function buildFirestoreCommand(
       if (options.withMeta) {
         argsWithDefaults.push('-m');
       }
-      return `${FIREBASE_EXTRA_PATH} firestore ${action} ${actionPath}`;
+      return `${FIREBASE_EXTRA_PATH} firestore ${action} ${actionPath} '${JSON.stringify(
+        fixturePath,
+      )}'`;
     }
   }
 }


### PR DESCRIPTION
When an update command is sent to firestore the data for update is not included. Therefore the following error message is returned: 

`update() requires either a single javascript object or an alternating list of field/value pairs`

By adding the object data in the command the corresponding document gets updated successfully.
