### PR TITLE
v0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4565,9 +4565,9 @@
       }
     },
     "firebase-tools-extra": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/firebase-tools-extra/-/firebase-tools-extra-0.0.8.tgz",
-      "integrity": "sha512-40P1k1r/BN5bMyclxH0puWaIoLotga4vnUZxSsNm6nRYXcP0MkiKj9OJycDzmyFGbDMeKnqSbPnSgQhBpMOaJA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/firebase-tools-extra/-/firebase-tools-extra-0.0.9.tgz",
+      "integrity": "sha512-ZDAnCFvNMjs2L2ba+0JrlKwkGetxkD2ZrZz9x9pO6Y3F4YP8X9TLXUdl/OKMNvULe0gljRUyhu+YNtYhQvOo/Q==",
       "requires": {
         "chalk": "^2.4.1",
         "firebase-admin": "^7.0.0",
@@ -4637,9 +4637,9 @@
           }
         },
         "p-limit": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -14095,9 +14095,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2056,7 +2056,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "dev": true,
       "requires": {
@@ -2455,7 +2455,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "optional": true,
           "requires": {
@@ -6964,7 +6964,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-object": {
@@ -7370,7 +7370,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -11600,7 +11600,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "optional": true,
       "requires": {
@@ -11609,7 +11609,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -13086,7 +13086,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -13375,7 +13375,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -14014,7 +14014,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -14072,7 +14072,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "commander": "^2.19.0",
     "figures": "^2.0.0",
     "firebase-admin": "^7.0.0",
-    "firebase-tools-extra": "^0.0.8",
+    "firebase-tools-extra": "^0.0.9",
     "lodash": "^4.17.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Utilities to help testing Firebase projects with Cypress.",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/attachCustomCommands.js
+++ b/src/attachCustomCommands.js
@@ -152,8 +152,12 @@ export default function({ Cypress, cy, firebase }) {
 
       // Add metadata to dataToWrite if specified by options
       if (isObject(data) && opts.withMeta) {
-        dataToWrite.createdBy = Cypress.env('TEST_UID');
-        dataToWrite.createdAt = firebase.firestore.FieldValue.serverTimestamp();
+        if (!dataToWrite.createdBy) {
+          dataToWrite.createdBy = Cypress.env('TEST_UID');
+        }
+        if (!dataToWrite.createdAt) {
+          dataToWrite.createdAt = new Date().toISOString();
+        }
       }
 
       const firestoreCommand = buildFirestoreCommand(


### PR DESCRIPTION
* fix(callFirestore): only attach `createdBy` and `createdAt` in meta if they do not already exist
* fix(callFirestore): parse `createdAt` to a timestamp (thanks to update of `firebase-tools-extra` to [`0.0.9`](https://github.com/prescottprue/firebase-tools-extra/releases/tag/v0.0.9))