### PR TITLE
fix(docs): improve explanation of how to create a service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ If you are intereted in what drove the need for this checkout [the why section](
 
 **Note**: Skip cypress install if it already exists within your project
 
-1. Log into your app for the first time
-1. Go to the Auth tab of Firebase and get your UID. This will be the account which you use to login while running tests (we will call this UID `TEST_UID`)
-1. Generate a service account -> save it as `serviceAccount.json` (for local dev)
+1. Log into your Firebase console for the first time.
+1. Go to Auth tab of Firebase and create a user for testing porpuse
+1. Get the UID of created account. This will be the account which you use to login while running tests (we will call this UID `TEST_UID`)
+1. Go to project setting on firebase console and generate new private key. See how to do [here](https://sites.google.com/site/scriptsexamples/new-connectors-to-google-services/firebase/tutorials/authenticate-with-a-service-account)
+1. Save the downloaded file as `serviceAccount.json` in the root of your project (for local dev)
 1. Set service account as the `SERVICE_ACCOUNT` environment variable within your CI (make sure to wrap it in `"`)
 1. Install Cypress and add it to your package file: `npm i --save-dev cypress`
 1. Add cypress folder by calling `cypress open`


### PR DESCRIPTION
Improves explanation about how to create a Firebase service account and use it.