### PR TITLE
v0.2.0-alpha.2

### DIFF
--- a/cmds/createTestEnvFile.js
+++ b/cmds/createTestEnvFile.js
@@ -42,7 +42,11 @@ function createTestEnvFile(envName) {
   // Throw if UID is missing in environment
   if (!uid) {
     /* eslint-disable */
-    const errMsg = `${chalk.cyan(varName)} is missing from environment. Confirm that ${chalk.cyan(configPath)} contains either ${chalk.cyan(varName)} or ${chalk.cyan('TEST_UID')}.`;
+    const errMsg = `${chalk.cyan(
+      varName
+    )} is missing from environment. Confirm that ${chalk.cyan(
+      configPath
+    )} contains either ${chalk.cyan(varName)} or ${chalk.cyan('TEST_UID')}.`;
     /* eslint-enable */
     return Promise.reject(new Error(errMsg));
   }
@@ -125,8 +129,12 @@ function createTestEnvFile(envName) {
       const newCypressConfig = Object.assign({}, currentCypressEnvSettings, {
         TEST_UID: envVarBasedOnCIEnv('TEST_UID'),
         FIREBASE_PROJECT_ID,
+        FIREBASE_API_KEY:
+          envVarBasedOnCIEnv('FIREBASE_API_KEY') ||
+          get(firebaserc, `ci.createConfig.${envName}.firebase.apiKey`, ''),
         FIREBASE_AUTH_JWT: customToken
       });
+
       const stageProjectId = envVarBasedOnCIEnv('STAGE_FIREBASE_PROJECT_ID');
       const stageApiKey = envVarBasedOnCIEnv('STAGE_FIREBASE_API_KEY');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.2.0-alpha",
+  "version": "0.2.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.2.0-alpha",
+  "version": "0.2.0-alpha.2",
   "description": "Utilities to help testing Firebase projects with Cypress.",
   "main": "lib/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
* feat(createTestEnvFile): add  `FIREBASE_API_KEY ` to generated`cypress.env.json` (supports loading config from `firebase-ci` settings in `.firebaserc`)