### PR TITLE
feat(auth): support passing developer claims when generating custom auth token

### DIFF
--- a/src/createTestEnvFile.js
+++ b/src/createTestEnvFile.js
@@ -85,10 +85,16 @@ export default function createTestEnvFile(envName) {
     'withServiceAccount',
   );
 
+  // Read developer claims object from cypress/config.json
+  const developerClaims = envVarBasedOnCIEnv('DEVELOPER_CLAIMS');
+  // Check if object is empty. If not, return it, otherwise set developer claims as { isTesting: true }
+  const defaultDeveloperClaims =
+    keys(developerClaims).length > 0 ? developerClaims : { isTesting: true };
+
   // Create auth token
   return appFromSA
     .auth()
-    .createCustomToken(uid, { isTesting: true })
+    .createCustomToken(uid, defaultDeveloperClaims)
     .then(customToken => {
       /* eslint-disable no-console */
       logger.success(


### PR DESCRIPTION
…check if the user defines those claims. Use default isTesting claim if not defined

resolves #35 