### PR TITLE
Get current user ID example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ during `build:testConfig` phase.
 cy.login()
 ```
 
+#### Get current UserId and aliases it for later usage.
+
+```javascript
+  //Assuming there's a uid property at the root level of the user object.
+  cy.login().then($auth => cy.wrap($auth).its('uid').as('uid'));
+  //Then, later somewhere in the test, use the uid like this,
+  cy.get('@uid').then((uid) => { 
+  //Your code here.
+  }
+```
+
 #### cy.logout
 
 Log out of Firebase instance


### PR DESCRIPTION
This PR adds an example for how to get and aliases the user id for the current logged in user.
Using Cypress alias allow us to get this value in a beforeEach call and use it later on, anywhere in the test.