### PR TITLE
v0.3.0-beta.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,15 @@ If you are interested in what drove the need for this checkout [the why section]
 1. Get the UID of created account. This will be the account which you use to login while running tests (we will call this UID `TEST_UID`)
 1. Go to project setting on firebase console and generate new private key. See how to do [here](https://sites.google.com/site/scriptsexamples/new-connectors-to-google-services/firebase/tutorials/authenticate-with-a-service-account)
 1. Save the downloaded file as `serviceAccount.json` in the root of your project (for local dev)
-1. Set service account as the `SERVICE_ACCOUNT` environment variable within your CI (make sure to wrap it in `"`)
+1. Set service account as the `SERVICE_ACCOUNT` environment variable within your CI
 1. Install Cypress and add it to your package file: `npm i --save-dev cypress`
 1. Add cypress folder by calling `cypress open`
+1. Add the following to your `.gitignore`:
+    ```
+    serviceAccount.json
+    cypress/config.json
+    cypress.env.json
+    ```
 
 ### Setup
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,9 @@ declare module "utils" {
 }
 declare module "buildFirestoreCommand" {
     export type FirestoreAction = 'delete' | 'set' | 'update' | 'get';
+    export interface FixtureData {
+        [k: string]: any;
+    }
     /**
      * Options for building Firestore commands
      */
@@ -88,16 +91,17 @@ declare module "buildFirestoreCommand" {
      * @param Cypress - Cypress object
      * @param action - action to run on Firstore (i.e. "add", "delete")
      * @param actionPath - Firestore path where action should be run
-     * @param fixturePath - Path to fixture. If object is passed,
+     * @param fixturePathOrData - Path to fixture. If object is passed,
      * it is used as options.
      * @param [opts={}] - Options object
      * @param opts.args - Extra arguments to be passed with command
      * @param opts.token - Firebase CI token to pass as the token argument
      * @returns Command string to be used with cy.exec
      */
-    export default function buildFirestoreCommand(Cypress: any, action: FirestoreAction, actionPath: string, fixturePath: FirestoreCommandOptions | string, opts?: FirestoreCommandOptions): string;
+    export default function buildFirestoreCommand(Cypress: any, action: FirestoreAction, actionPath: string, fixturePathOrData?: FixtureData | string | FirestoreCommandOptions, opts?: FirestoreCommandOptions): string;
 }
 declare module "buildRtdbCommand" {
+    import { FixtureData } from "buildFirestoreCommand";
     export type RTDBAction = 'remove' | 'set' | 'update' | 'delete' | 'get';
     export interface RTDBCommandOptions {
         withMeta?: boolean;
@@ -118,14 +122,11 @@ declare module "buildRtdbCommand" {
      * @param opts.args - Extra arguments to be passed with command
      * @returns Command string to be used with cy.exec
      */
-    export default function buildRtdbCommand(Cypress: any, action: RTDBAction, actionPath: string, fixturePath: RTDBCommandOptions | string, opts?: RTDBCommandOptions): string;
+    export default function buildRtdbCommand(Cypress: any, action: RTDBAction, actionPath: string, fixturePath?: FixtureData | RTDBCommandOptions | any, opts?: RTDBCommandOptions): string;
 }
 declare module "attachCustomCommands" {
-    import { FirestoreAction, FirestoreCommandOptions } from "buildFirestoreCommand";
+    import { FirestoreAction, FirestoreCommandOptions, FixtureData } from "buildFirestoreCommand";
     import { RTDBAction, RTDBCommandOptions } from "buildRtdbCommand";
-    export interface FixtureData {
-        [k: string]: any;
-    }
     export interface AttachCustomCommandParams {
         Cypress: any;
         cy: any;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.3.0-beta.3",
+  "version": "0.3.0-beta.4",
   "description": "Utilities to help testing Firebase projects with Cypress.",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/buildRtdbCommand.ts
+++ b/src/buildRtdbCommand.ts
@@ -29,10 +29,12 @@ export default function buildRtdbCommand(
   Cypress: any,
   action: RTDBAction,
   actionPath: string,
-  fixturePath?: FixtureData | RTDBCommandOptions | string,
-  opts: RTDBCommandOptions = {},
+  fixturePath?: FixtureData | RTDBCommandOptions | any,
+  opts?: RTDBCommandOptions,
 ): string {
-  const options = isObject(fixturePath) ? fixturePath : opts;
+  const options: RTDBCommandOptions = isObject(fixturePath)
+    ? fixturePath
+    : opts || {};
   const { args = [] } = options;
   const argsWithDefaults = addDefaultArgs(Cypress, args);
   const argsStr = getArgsString(argsWithDefaults);
@@ -67,9 +69,11 @@ export default function buildRtdbCommand(
       return `${FIREBASE_TOOLS_BASE_COMMAND} database:${action} ${cleanActionPath}${getDataArgsStr}`;
     }
     default: {
-      return `${FIREBASE_TOOLS_BASE_COMMAND} database:${action} ${cleanActionPath} -d '${JSON.stringify(
-        options,
-      )}'${argsStr}`;
+      const commandString = `${FIREBASE_TOOLS_BASE_COMMAND} database:${action} ${cleanActionPath}`;
+      if (!isObject(fixturePath)) {
+        return `${commandString} ${fixturePath}${argsStr}`;
+      }
+      return `${commandString} -d '${JSON.stringify(fixturePath)}'${argsStr}`;
     }
   }
 }

--- a/src/createTestEnvFile.ts
+++ b/src/createTestEnvFile.ts
@@ -53,8 +53,6 @@ export default async function createTestEnvFile(
   const FIREBASE_PROJECT_ID =
     get(currentCypressEnvSettings, 'FIREBASE_PROJECT_ID') ||
     envVarBasedOnCIEnv('FIREBASE_PROJECT_ID', envName) ||
-    envVarBasedOnCIEnv(`${envPrefix}FIREBASE_PROJECT_ID`, envName) ||
-    envVarBasedOnCIEnv('FIREBASE_PROJECT_ID', envName) ||
     get(
       firebaserc,
       `projects.${envName}`,
@@ -77,7 +75,7 @@ export default async function createTestEnvFile(
     const errMsg = `Service Account is missing parameters: ${Object.keys(
       serviceAccountMissingParams,
     ).join(', ')}`;
-    return Promise.reject(new Error(errMsg));
+    throw new Error(errMsg);
   }
 
   // Remove firebase- prefix (was added to database names for a short period of time)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export function addDefaultArgs(
   args: string[],
   opts?: any,
 ): string[] {
-  const { disableYes = false, token } = opts || {};
+  const { disableYes = false, token, withMeta } = opts || {};
   const newArgs = [...args];
   // TODO: Load this in a way that understands environment. Currently this will
   // go to the first project id that is defined, not which one should be used
@@ -103,6 +103,10 @@ export function addDefaultArgs(
   // Add Firebase's automatic approval argument if it is not already in newArgs
   if (!disableYes && !newArgs.includes(FIREBASE_TOOLS_YES_ARGUMENT)) {
     newArgs.push(FIREBASE_TOOLS_YES_ARGUMENT);
+  }
+  if (withMeta) {
+    // Add -m to argsWithDefaults string (meta) if withmeta option is true
+    newArgs.push('-m');
   }
   return newArgs;
 }

--- a/test/unit/buildFirestoreCommand.spec.ts
+++ b/test/unit/buildFirestoreCommand.spec.ts
@@ -7,24 +7,38 @@ const envSpy = sinon.spy()
 const Cypress = { Commands: { add: addSpy }, env: envSpy }
 
 const firebaseExtraPath = '$(npm bin)/firebase-extra'
+const firebaseToolsPath = '$(npm bin)/firebase'
 
 describe('buildFirestoreCommand', () => {
   describe('get', () => {
     it('calls get with a path', () => {
       const actionPath = 'some/path'
-      const action = 'get'
-      expect(buildFirestoreCommand(Cypress, action, actionPath))
-        .to.equal(`${firebaseExtraPath} firestore ${action} ${actionPath}`)
+      expect(buildFirestoreCommand(Cypress, 'get', actionPath))
+        .to.equal(`${firebaseExtraPath} firestore get ${actionPath}`)
     })
   });
 
   describe('set', () => {
-    it('calls set with a path', () => {
+    it('creates a set command with path and object data', () => {
+      const actionPath = 'some/path'
+      const data = { some: 'other' }
+      expect(buildFirestoreCommand(Cypress, 'set', actionPath, data))
+        .to.equal(`${firebaseExtraPath} firestore set ${actionPath} '${JSON.stringify(data)}'`)
+    })
+
+    it('creates a set command with path, object data, and withMeta flag', () => {
+      const actionPath = 'some/path'
+      const data = { some: 'other' }
+      expect(buildFirestoreCommand(Cypress, 'set', actionPath, data, { withMeta: true }))
+        .to.equal(`${firebaseExtraPath} firestore set ${actionPath} '${JSON.stringify(data)}' -m`)
+    })
+
+    it('creates a set command with path, fixture path, and withMeta flag', () => {
       const actionPath = 'some/path'
       const action = 'set'
-      const data = { some: 'other' }
-      expect(buildFirestoreCommand(Cypress, action, actionPath, data))
-        .to.equal(`${firebaseExtraPath} firestore ${action} ${actionPath} '${JSON.stringify(data)}'`)
+      const fixturePath = 'some/fixture'
+      expect(buildFirestoreCommand(Cypress, action, actionPath, fixturePath, { withMeta: true }))
+        .to.equal(`${firebaseExtraPath} firestore ${action} ${actionPath} ${fixturePath} -m`)
     })
   });
 
@@ -35,6 +49,20 @@ describe('buildFirestoreCommand', () => {
       const data = { some: 'other' }
       expect(buildFirestoreCommand(Cypress, action, actionPath, data))
         .to.equal(`${firebaseExtraPath} firestore ${action} ${actionPath} '${JSON.stringify(data)}'`)
+    })
+  });
+
+  describe('delete', () => {
+    it('calls delete with a path and --shallow by default', () => {
+      const actionPath = 'some/path'
+      expect(buildFirestoreCommand(Cypress, 'delete', actionPath))
+        .to.equal(`${firebaseToolsPath} firestore:delete ${actionPath} -y --shallow`)
+    })
+
+    it('supports recursive delete (by passing -r flag)', () => {
+      const actionPath = 'some/path'
+      expect(buildFirestoreCommand(Cypress, 'delete', actionPath, { recursive: true }))
+        .to.equal(`${firebaseToolsPath} firestore:delete ${actionPath} -y -r`)
     })
   });
 });

--- a/test/unit/buildRtdbCommand.spec.ts
+++ b/test/unit/buildRtdbCommand.spec.ts
@@ -19,12 +19,28 @@ describe('buildRtdbCommand', () => {
   });
 
   describe('set', () => {
-    it('calls set with a path', () => {
+    it('creates a set command with path and object data', () => {
       const actionPath = 'some/path'
       const action = 'set'
       const data = { some: 'other' }
       expect(buildRtdbCommand(Cypress, action, actionPath, data))
         .to.equal(`${firebasePath} database:${action} /${actionPath} -d '${JSON.stringify(data)}' -y`)
+    })
+
+    it('creates a set command with path and non-string value', () => {
+      const actionPath = 'some/path'
+      const action = 'set'
+      const data = 123
+      expect(buildRtdbCommand(Cypress, action, actionPath, data))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} ${data} -y`)
+    })
+
+    it('creates a set command with path and string value', () => {
+      const actionPath = 'some/path'
+      const action = 'set'
+      const data = '123ABC'
+      expect(buildRtdbCommand(Cypress, action, actionPath, data))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} ${data} -y`)
     })
   });
 


### PR DESCRIPTION
* fix(cy.callRtdb): only add `-d` flag when data is an object
* fix(cy.callFirestore): fixture path no longer stringified - #39
* feat(cy.callRtdb): fix writing a non object value with `set` - #60
* feat(tests): add tests for string value - #39
* feat(docs): add note to README about adding files to `.gitignore` - #23