### PR TITLE
v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,17 +185,6 @@ during `build:testConfig` phase.
 cy.login()
 ```
 
-#### Get current UserId and aliases it for later usage.
-
-```javascript
-  //Assuming there's a uid property at the root level of the user object.
-  cy.login().then($auth => cy.wrap($auth).its('uid').as('uid'));
-  //Then, later somewhere in the test, use the uid like this,
-  cy.get('@uid').then((uid) => { 
-  //Your code here.
-  }
-```
-
 #### cy.logout
 
 Log out of Firebase instance
@@ -214,7 +203,16 @@ Call Real Time Database path with some specified action. Authentication is throu
 
 -   `action` **[String][11]** The action type to call with (set, push, update, remove)
 -   `actionPath` **[String][11]** Path within RTDB that action should be applied
--   `opts` **[Object][12]** Options
+-   `opts` **[object][12]** Options
+    -   `opts.limitToFirst` **[number|boolean][13]** Limit to the first `<num>` results. If true is passed than query is limited to last 1 item.
+    -   `opts.limitToLast` **[number|boolean][13]** Limit to the last `<num>` results. If true is passed than query is limited to last 1 item.
+    -   `opts.orderByKey` **[boolean][13]** Order by key name
+    -   `opts.orderByValue` **[boolean][13]** Order by primitive value
+    -   `opts.orderByChild` **[string][11]** Select a child key by which to order results
+    -   `opts.equalTo` **[string][11]** Restrict results to `<val>` (based on specified ordering)
+    -   `opts.startAt` **[string][11]** Start results at `<val>` (based on specified ordering)
+    -   `opts.endAt` **[string][11]** End results at `<val>` (based on specified ordering)
+    -   `opts.instance` **[string][11]** Use the database `<instance>.firebaseio.com` (if omitted, use default database instance)
     -   `opts.args` **[Array][13]** Command line args to be passed
 
 ##### Examples

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,15 +18,6 @@ declare module "utils" {
      */
     export function to<T, U = Error>(promise: Promise<T>, errorExt?: object): Promise<[U | null, T | undefined]>;
     /**
-     * Convert slash path to Firestore reference
-     * @param firestoreInstance - Instance on which to
-     * create ref
-     * @param slashPath - Path to convert into firestore refernce
-     * @param options - Options object
-     * @returns Ref at slash path
-     */
-    export function slashPathToFirestoreRef(firestoreInstance: any, slashPath: string, options?: any): any;
-    /**
      * Create command arguments string from an array of arguments by joining them
      * with a space including a leading space. If no args provided, empty string
      * is returned
@@ -44,18 +35,6 @@ declare module "utils" {
      * @returns Default args list
      */
     export function addDefaultArgs(Cypress: any, args: string[], opts?: any): string[];
-    /**
-     * Check to see if the provided value is a promise object
-     * @param valToCheck - Value to be checked for Promise qualities
-     * @returns Whether or not provided value is a promise
-     */
-    export function isPromise(valToCheck: any): boolean;
-    /**
-     * Escape shell command arguments and join them to a single string
-     * @param a - List of arguments to escape
-     * @returns Command string with arguments escaped
-     */
-    export function shellescape(a: string[]): string;
 }
 declare module "buildFirestoreCommand" {
     export type FirestoreAction = 'delete' | 'set' | 'update' | 'get';

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,13 @@ declare module "utils" {
     export function addDefaultArgs(Cypress: any, args: string[], opts?: any): string[];
 }
 declare module "buildFirestoreCommand" {
+    /**
+     * Action for Firestore
+     */
     export type FirestoreAction = 'delete' | 'set' | 'update' | 'get';
+    /**
+     * Data from loaded fixture
+     */
     export interface FixtureData {
         [k: string]: any;
     }
@@ -81,13 +87,64 @@ declare module "buildFirestoreCommand" {
 }
 declare module "buildRtdbCommand" {
     import { FixtureData } from "buildFirestoreCommand";
+    /**
+     * Action for Real Time Database
+     */
     export type RTDBAction = 'remove' | 'set' | 'update' | 'delete' | 'get';
+    /**
+     * Options for callRtdb commands
+     */
     export interface RTDBCommandOptions {
+        /**
+         * Whether or not to include meta data
+         */
         withMeta?: boolean;
+        /**
+         * Extra arguments
+         */
         args?: string[];
+        /**
+         * CI Token
+         */
         token?: string;
-        limitToLast?: boolean;
-        orderByChild?: boolean;
+        /**
+         * Limit to the last <num> results. If true is passed
+         * than query is limited to last 1 item.
+         */
+        limitToLast?: boolean | number;
+        /**
+         * Limit to the first <num> results. If true is passed
+         * than query is limited to last 1 item.
+         */
+        limitToFirst?: boolean | number;
+        /**
+         * Select a child key by which to order results
+         */
+        orderByChild?: string;
+        /**
+         * Order by key name
+         */
+        orderByKey?: boolean;
+        /**
+         * Order by primitive value
+         */
+        orderByValue?: boolean;
+        /**
+         * Start results at <val> (based on specified ordering)
+         */
+        startAt?: any;
+        /**
+         * End results at <val> (based on specified ordering)
+         */
+        endAt?: any;
+        /**
+         * Restrict results to <val> (based on specified ordering)
+         */
+        equalTo?: any;
+        /**
+         * Use the database <instance>.firebaseio.com (if omitted, use default database instance)
+         */
+        instance?: string;
     }
     /**
      * Build Command to run Real Time Database action. All commands call
@@ -131,7 +188,8 @@ declare module "attachCustomCommands" {
                 logout: () => Chainable;
                 /**
                  * Call Real Time Database path with some specified action. Authentication is through
-                 * FIREBASE_TOKEN since firebase-tools is used (instead of firebaseExtra).
+                 * `FIREBASE_TOKEN` (CI token) since firebase-tools is used under the hood, allowing
+                 * for adming privileges.
                  * @param action - The action type to call with (set, push, update, remove)
                  * @param actionPath - Path within RTDB that action should be applied
                  * @param opts - Options
@@ -140,14 +198,14 @@ declare module "attachCustomCommands" {
                  * @example <caption>Set Data</caption>
                  * const fakeProject = { some: 'data' }
                  * cy.callRtdb('set', 'projects/ABC123', fakeProject)
-                 * @example <caption>Set Data With Meta</caption>
+                 * @example <caption>Set Data With Meta Data</caption>
                  * const fakeProject = { some: 'data' }
                  * // Adds createdAt and createdBy (current user's uid) on data
                  * cy.callRtdb('set', 'projects/ABC123', fakeProject, { withMeta: true })
                  * @example <caption>Passing Other Arguments</caption>
-                 * const opts = { args: ['-d'] }
+                 * const options = { args: ['-d'] }
                  * const fakeProject = { some: 'data' }
-                 * cy.callRtdb('update', 'project/test-project', fakeProject, opts)
+                 * cy.callRtdb('update', 'project/test-project', fakeProject, options)
                  */
                 callRtdb: (action: RTDBAction, actionPath: string, fixtureDataOrPath?: FixtureData | string, opts?: RTDBCommandOptions) => Chainable;
                 /**
@@ -160,25 +218,25 @@ declare module "attachCustomCommands" {
                  * @param opts - Options
                  * @param opts.args - Command line args to be passed
                  * @see https://github.com/prescottprue/cypress-firebase#cycallfirestore
-                 * @example <caption>Basic Set</caption>
+                 * @example <caption>Set Data</caption>
                  * const project = { some: 'data' }
                  * cy.callFirestore('set', 'project/test-project', project)
-                 * @example <caption>Basic Add</caption>
+                 * @example <caption>Add New Document</caption>
                  * const project = { some: 'data' }
                  * cy.callFirestore('add', 'projects', project)
                  * @example <caption>Basic Get</caption>
                  * cy.callFirestore('get', 'projects/test-project').then((project) => {
                  *   cy.log('Project:', project)
                  * })
+                 * @example <caption>Recursive Delete</caption>
+                 * const opts = { recursive: true }
+                 * cy.callFirestore('delete', 'project/test-project', opts)
                  * @example <caption>Manually Loading Fixture</caption>
                  * cy.fixture('fakeProject.json').then((project) => {
                  *   cy.callFirestore('add', 'projects', project)
                  * })
                  * @example <caption>Fixture Path</caption>
                  * cy.callFirestore('set', 'project/test-project', 'fakeProject.json')
-                 * @example <caption>Recursive Delete</caption>
-                 * const opts = { recursive: true }
-                 * cy.callFirestore('delete', 'project/test-project', opts)
                  * @example <caption>Other Args</caption>
                  * const opts = { args: ['-r'] }
                  * cy.callFirestore('delete', 'project/test-project', opts)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Utilities to help testing Firebase projects with Cypress.",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Utilities to help testing Firebase projects with Cypress.",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "chalk": "^2.4.2",
     "commander": "^3.0.0",
     "figures": "^3.0.0",
-    "firebase-admin": "^8.5.0",
-    "firebase-tools-extra": "0.1.1",
+    "firebase-admin": "^8.6.1",
+    "firebase-tools-extra": "0.2.0-alpha",
     "lodash": "^4.17.15"
   },
   "devDependencies": {
@@ -52,7 +52,7 @@
     "eslint-plugin-jsdoc": "^15.9.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.0",
-    "firebase-tools": "^7.3.1",
+    "firebase-tools": "^7.6.1",
     "husky": "^3.0.4",
     "mocha": "^6.2.1",
     "prettier": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commander": "^3.0.0",
     "figures": "^3.0.0",
     "firebase-admin": "^8.6.1",
-    "firebase-tools-extra": "0.2.0-alpha",
+    "firebase-tools-extra": "0.2.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -273,18 +273,17 @@ export default function attachCustomCommands(
 
       cy.log(`Calling Firestore command:\n${firestoreCommand}`);
 
-      cy.exec(firestoreCommand, { timeout: 100000 }).then((out: any) => {
+      return cy.exec(firestoreCommand, { timeout: 100000 }).then((out: any) => {
         const { stdout, stderr } = out;
         // Reject with Error if error in firestoreCommand call
         if (stderr) {
           cy.log(`Error in Firestore Command:\n${stderr}`);
           return Promise.reject(stderr);
         }
-
         // Parse result if using get action so that data can be verified
-        if (action === 'get' && typeof stdout === 'string') {
+        if (action === 'get' && (typeof stdout === 'string' || stdout instanceof String)) {
           try {
-            return JSON.parse(stdout);
+            return JSON.parse(stdout instanceof String ? stdout.toString() : stdout);
           } catch (err) {
             cy.log('Error parsing data from callFirestore response', out);
             return Promise.reject(err);

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -40,7 +40,8 @@ declare global {
 
       /**
        * Call Real Time Database path with some specified action. Authentication is through
-       * FIREBASE_TOKEN since firebase-tools is used (instead of firebaseExtra).
+       * `FIREBASE_TOKEN` (CI token) since firebase-tools is used under the hood, allowing
+       * for adming privileges.
        * @param action - The action type to call with (set, push, update, remove)
        * @param actionPath - Path within RTDB that action should be applied
        * @param opts - Options
@@ -49,14 +50,14 @@ declare global {
        * @example <caption>Set Data</caption>
        * const fakeProject = { some: 'data' }
        * cy.callRtdb('set', 'projects/ABC123', fakeProject)
-       * @example <caption>Set Data With Meta</caption>
+       * @example <caption>Set Data With Meta Data</caption>
        * const fakeProject = { some: 'data' }
        * // Adds createdAt and createdBy (current user's uid) on data
        * cy.callRtdb('set', 'projects/ABC123', fakeProject, { withMeta: true })
        * @example <caption>Passing Other Arguments</caption>
-       * const opts = { args: ['-d'] }
+       * const options = { args: ['-d'] }
        * const fakeProject = { some: 'data' }
-       * cy.callRtdb('update', 'project/test-project', fakeProject, opts)
+       * cy.callRtdb('update', 'project/test-project', fakeProject, options)
        */
       callRtdb: (
         action: RTDBAction,
@@ -75,25 +76,25 @@ declare global {
        * @param opts - Options
        * @param opts.args - Command line args to be passed
        * @see https://github.com/prescottprue/cypress-firebase#cycallfirestore
-       * @example <caption>Basic Set</caption>
+       * @example <caption>Set Data</caption>
        * const project = { some: 'data' }
        * cy.callFirestore('set', 'project/test-project', project)
-       * @example <caption>Basic Add</caption>
+       * @example <caption>Add New Document</caption>
        * const project = { some: 'data' }
        * cy.callFirestore('add', 'projects', project)
        * @example <caption>Basic Get</caption>
        * cy.callFirestore('get', 'projects/test-project').then((project) => {
        *   cy.log('Project:', project)
        * })
+       * @example <caption>Recursive Delete</caption>
+       * const opts = { recursive: true }
+       * cy.callFirestore('delete', 'project/test-project', opts)
        * @example <caption>Manually Loading Fixture</caption>
        * cy.fixture('fakeProject.json').then((project) => {
        *   cy.callFirestore('add', 'projects', project)
        * })
        * @example <caption>Fixture Path</caption>
        * cy.callFirestore('set', 'project/test-project', 'fakeProject.json')
-       * @example <caption>Recursive Delete</caption>
-       * const opts = { recursive: true }
-       * cy.callFirestore('delete', 'project/test-project', opts)
        * @example <caption>Other Args</caption>
        * const opts = { args: ['-r'] }
        * cy.callFirestore('delete', 'project/test-project', opts)
@@ -123,8 +124,6 @@ export default function attachCustomCommands(
    * which is generated using firebase-admin authenticated with serviceAccount
    * during test:buildConfig phase.
    * @name cy.login
-   * @example
-   * cy.login()
    */
   Cypress.Commands.add('login', (): any => {
     /** Log in using token * */
@@ -174,7 +173,8 @@ export default function attachCustomCommands(
   );
 
   /**
-   * Call Real Time Database path with some specified action. Authentication is through FIREBASE_TOKEN since firebase-tools is used (instead of firebaseExtra).
+   * Call Real Time Database path with some specified action. Authentication is through
+   * FIREBASE_TOKEN since firebase-tools is used (instead of firebaseExtra).
    * @param action - The action type to call with (set, push, update, remove)
    * @param actionPath - Path within RTDB that action should be applied
    * @param opts - Options
@@ -281,9 +281,14 @@ export default function attachCustomCommands(
           return Promise.reject(stderr);
         }
         // Parse result if using get action so that data can be verified
-        if (action === 'get' && (typeof stdout === 'string' || stdout instanceof String)) {
+        if (
+          action === 'get' &&
+          (typeof stdout === 'string' || stdout instanceof String)
+        ) {
           try {
-            return JSON.parse(stdout instanceof String ? stdout.toString() : stdout);
+            return JSON.parse(
+              stdout instanceof String ? stdout.toString() : stdout,
+            );
           } catch (err) {
             cy.log('Error parsing data from callFirestore response', out);
             return Promise.reject(err);

--- a/src/buildFirestoreCommand.ts
+++ b/src/buildFirestoreCommand.ts
@@ -2,8 +2,14 @@ import { isObject } from 'lodash';
 import { addDefaultArgs, getArgsString } from './utils';
 import { FIREBASE_TOOLS_BASE_COMMAND, FIREBASE_EXTRA_PATH } from './constants';
 
+/**
+ * Action for Firestore
+ */
 export type FirestoreAction = 'delete' | 'set' | 'update' | 'get';
 
+/**
+ * Data from loaded fixture
+ */
 export interface FixtureData {
   [k: string]: any;
 }

--- a/src/buildRtdbCommand.ts
+++ b/src/buildRtdbCommand.ts
@@ -61,7 +61,7 @@ export default function buildRtdbCommand(
           );
         } else {
           getDataArgsWithDefaults.push(
-            `--order-by-child ${options.orderByChild} --limit-to-last ${lastCount}`,
+            `--order-by ${options.orderByChild} --limit-to-last ${lastCount}`,
           );
         }
       }

--- a/src/buildRtdbCommand.ts
+++ b/src/buildRtdbCommand.ts
@@ -3,14 +3,152 @@ import { FixtureData } from './buildFirestoreCommand';
 import { addDefaultArgs, getArgsString } from './utils';
 import { FIREBASE_TOOLS_BASE_COMMAND } from './constants';
 
+/**
+ * Action for Real Time Database
+ */
 export type RTDBAction = 'remove' | 'set' | 'update' | 'delete' | 'get';
 
+/**
+ * Options for callRtdb commands
+ */
 export interface RTDBCommandOptions {
+  /**
+   * Whether or not to include meta data
+   */
   withMeta?: boolean;
+  /**
+   * Extra arguments
+   */
   args?: string[];
+  /**
+   * CI Token
+   */
   token?: string;
-  limitToLast?: boolean;
-  orderByChild?: boolean;
+  /**
+   * Limit to the last <num> results. If true is passed
+   * than query is limited to last 1 item.
+   */
+  limitToLast?: boolean | number;
+  /**
+   * Limit to the first <num> results. If true is passed
+   * than query is limited to last 1 item.
+   */
+  limitToFirst?: boolean | number;
+  /**
+   * Select a child key by which to order results
+   */
+  orderByChild?: string;
+  /**
+   * Order by key name
+   */
+  orderByKey?: boolean;
+  /**
+   * Order by primitive value
+   */
+  orderByValue?: boolean;
+  /**
+   * Start results at <val> (based on specified ordering)
+   */
+  startAt?: any;
+  /**
+   * End results at <val> (based on specified ordering)
+   */
+  endAt?: any;
+  /**
+   * Restrict results to <val> (based on specified ordering)
+   */
+  equalTo?: any;
+  /**
+   * Use the database <instance>.firebaseio.com (if omitted, use default database instance)
+   */
+  instance?: string;
+}
+
+const ARGS_MAP = {
+  orderByChild: '--order-by',
+  orderByKey: '--order-by-key',
+  orderByValue: '--order-by-value',
+  limitToFirst: '--limit-to-first',
+  limitToLast: '--limit-to-last',
+  startAt: '--start-at',
+  endAt: '--end-at',
+  equalTo: '--equal-to',
+  instance: '--instance',
+};
+
+/**
+ * Generate RTDB args from command options
+ * @param Cypress - Cypress object
+ * @param args - Extra arguments to be passed with command
+ * @param [options={}] - Options object
+ * @returns A list of args for get command
+ */
+function generageRtdbGetArgs(
+  Cypress: any,
+  args: any[],
+  options: RTDBCommandOptions,
+): string[] {
+  const getDataArgsWithDefaults = addDefaultArgs(Cypress, args, {
+    disableYes: true,
+  });
+
+  if (options.orderByChild && !options.limitToLast && !options.limitToLast) {
+    getDataArgsWithDefaults.push(ARGS_MAP.orderByChild);
+    getDataArgsWithDefaults.push(options.orderByChild);
+  }
+  if (options.orderByKey && !options.limitToLast) {
+    getDataArgsWithDefaults.push(ARGS_MAP.orderByKey);
+  }
+  if (options.orderByValue) {
+    getDataArgsWithDefaults.push(ARGS_MAP.orderByValue);
+  }
+  if (options.startAt) {
+    getDataArgsWithDefaults.push(ARGS_MAP.startAt);
+    getDataArgsWithDefaults.push(options.startAt);
+  }
+  if (options.endAt) {
+    getDataArgsWithDefaults.push(ARGS_MAP.endAt);
+    getDataArgsWithDefaults.push(options.endAt);
+  }
+  if (options.equalTo) {
+    getDataArgsWithDefaults.push(ARGS_MAP.equalTo);
+    getDataArgsWithDefaults.push(options.equalTo);
+  }
+
+  if (options.instance) {
+    getDataArgsWithDefaults.push(ARGS_MAP.instance);
+    getDataArgsWithDefaults.push(options.instance);
+  }
+
+  if (options.limitToLast) {
+    const lastCount = isBoolean(options.limitToLast) ? 1 : options.limitToLast;
+    if (!options.orderByChild) {
+      getDataArgsWithDefaults.push(
+        `--order-by-key --limit-to-last ${lastCount}`,
+      );
+    } else {
+      getDataArgsWithDefaults.push(
+        `--order-by ${options.orderByChild} --limit-to-last ${lastCount}`,
+      );
+    }
+  }
+
+  if (options.limitToFirst) {
+    const lastCount = isBoolean(options.limitToFirst)
+      ? 1
+      : options.limitToFirst;
+    if (!options.orderByChild) {
+      getDataArgsWithDefaults.push(
+        `--order-by-key --limit-to-first ${lastCount}`,
+      );
+    } else {
+      getDataArgsWithDefaults.push(
+        `--order-by ${options.orderByChild} --limit-to-first ${lastCount}`,
+      );
+    }
+  }
+
+  return getDataArgsWithDefaults;
 }
 
 /**
@@ -48,23 +186,11 @@ export default function buildRtdbCommand(
     case 'delete':
       return `${FIREBASE_TOOLS_BASE_COMMAND} database:remove ${cleanActionPath}${argsStr}`;
     case 'get': {
-      const getDataArgsWithDefaults = addDefaultArgs(Cypress, args, {
-        disableYes: true,
-      });
-      if (options.limitToLast) {
-        const lastCount = isBoolean(options.limitToLast)
-          ? 1
-          : options.limitToLast;
-        if (!options.orderByChild) {
-          getDataArgsWithDefaults.push(
-            `--order-by-key --limit-to-last ${lastCount}`,
-          );
-        } else {
-          getDataArgsWithDefaults.push(
-            `--order-by ${options.orderByChild} --limit-to-last ${lastCount}`,
-          );
-        }
-      }
+      const getDataArgsWithDefaults = generageRtdbGetArgs(
+        Cypress,
+        args,
+        options,
+      );
       const getDataArgsStr = getArgsString(getDataArgsWithDefaults);
       return `${FIREBASE_TOOLS_BASE_COMMAND} database:${action} ${cleanActionPath}${getDataArgsStr}`;
     }

--- a/src/createTestEnvFile.ts
+++ b/src/createTestEnvFile.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
-import fs from 'fs';
+import { writeFile } from 'fs';
 import { pickBy, get, isUndefined } from 'lodash';
+import { promisify } from 'util'
 import {
   envVarBasedOnCIEnv,
   getServiceAccount,
@@ -12,6 +13,8 @@ import { to } from './utils';
 import { DEFAULT_TEST_ENV_FILE_NAME } from './constants';
 import { FIREBASE_CONFIG_FILE_PATH, TEST_ENV_FILE_PATH } from './filePaths';
 import * as logger from './logger';
+
+const writeFilePromise = promisify(writeFile)
 
 /* eslint-disable no-irregular-whitespace */
 /**
@@ -146,7 +149,7 @@ export default async function createTestEnvFile(
   }
 
   // Write config file to cypress.env.json
-  fs.writeFileSync(
+  await writeFilePromise(
     TEST_ENV_FILE_PATH,
     JSON.stringify(newCypressConfig, null, 2),
   );

--- a/src/createTestEnvFile.ts
+++ b/src/createTestEnvFile.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { writeFile } from 'fs';
 import { pickBy, get, isUndefined } from 'lodash';
-import { promisify } from 'util'
+import { promisify } from 'util';
 import {
   envVarBasedOnCIEnv,
   getServiceAccount,
@@ -14,7 +14,7 @@ import { DEFAULT_TEST_ENV_FILE_NAME } from './constants';
 import { FIREBASE_CONFIG_FILE_PATH, TEST_ENV_FILE_PATH } from './filePaths';
 import * as logger from './logger';
 
-const writeFilePromise = promisify(writeFile)
+const writeFilePromise = promisify(writeFile);
 
 /* eslint-disable no-irregular-whitespace */
 /**

--- a/src/extendWithFirebaseConfig.ts
+++ b/src/extendWithFirebaseConfig.ts
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
-import { existsSync, readFileSync } from 'fs';
-import * as logger from './logger';
+import { existsSync } from 'fs';
+import { FIREBASE_CONFIG_FILE_NAME } from './constants'
+import { readJsonFile } from './node-utils';
 
 export interface CypressEnvironmentOptions {
   envName?: string;
@@ -30,17 +31,11 @@ export interface ExtendWithFirebaseConfigSettings {
  * @returns Contents of .firebaserc file parsed as JSON
  */
 function loadFirebaseRc(): string {
-  const rcFilePath = `${process.cwd()}/.firebaserc`;
+  const rcFilePath = `${process.cwd()}/${FIREBASE_CONFIG_FILE_NAME}`;
   if (!existsSync(rcFilePath)) {
-    throw new Error('.firebaserc file not found');
+    throw new Error(`${FIREBASE_CONFIG_FILE_NAME} file not found`);
   }
-  try {
-    const fileBuffer = readFileSync(rcFilePath);
-    return JSON.parse(fileBuffer.toString());
-  } catch (err) {
-    logger.error('Error loading .firebaserc: ', err); // eslint-disable-line no-console
-    throw err;
-  }
+  return readJsonFile(rcFilePath)
 }
 
 /**

--- a/src/extendWithFirebaseConfig.ts
+++ b/src/extendWithFirebaseConfig.ts
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import { existsSync } from 'fs';
-import { FIREBASE_CONFIG_FILE_NAME } from './constants'
+import { FIREBASE_CONFIG_FILE_NAME } from './constants';
 import { readJsonFile } from './node-utils';
 
 export interface CypressEnvironmentOptions {
@@ -35,7 +35,7 @@ function loadFirebaseRc(): string {
   if (!existsSync(rcFilePath)) {
     throw new Error(`${FIREBASE_CONFIG_FILE_NAME} file not found`);
   }
-  return readJsonFile(rcFilePath)
+  return readJsonFile(rcFilePath);
 }
 
 /**

--- a/src/node-utils.ts
+++ b/src/node-utils.ts
@@ -25,7 +25,7 @@ export function readJsonFile(filePath: string): any {
   }
 
   try {
-    const fileBuffer = readFileSync(filePath, 'utf8')
+    const fileBuffer = readFileSync(filePath, 'utf8');
     return JSON.parse(fileBuffer.toString());
   } catch (err) {
     error(

--- a/src/node-utils.ts
+++ b/src/node-utils.ts
@@ -25,7 +25,8 @@ export function readJsonFile(filePath: string): any {
   }
 
   try {
-    return JSON.parse(readFileSync(filePath, 'utf8'));
+    const fileBuffer = readFileSync(filePath, 'utf8')
+    return JSON.parse(fileBuffer.toString());
   } catch (err) {
     error(
       `Unable to parse ${chalk.cyan(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { FIREBASE_TOOLS_YES_ARGUMENT } from './constants';
 
 /**
@@ -20,39 +19,6 @@ export function to<T, U = Error>(
 
       return [err, undefined];
     });
-}
-
-/**
- * Convert slash path to Firestore reference
- * @param firestoreInstance - Instance on which to
- * create ref
- * @param slashPath - Path to convert into firestore refernce
- * @param options - Options object
- * @returns Ref at slash path
- */
-export function slashPathToFirestoreRef(
-  firestoreInstance: any,
-  slashPath: string,
-  options?: any,
-): any {
-  let ref = firestoreInstance;
-  const srcPathArr = slashPath.split('/');
-  srcPathArr.forEach(pathSegment => {
-    if (ref.collection) {
-      ref = ref.collection(pathSegment);
-    } else if (ref.doc) {
-      ref = ref.doc(pathSegment);
-    } else {
-      throw new Error(`Invalid slash path: ${slashPath}`);
-    }
-  });
-
-  // Apply limit to query if it exists
-  if (options && options.limit && typeof ref.limit === 'function') {
-    ref = ref.limit(options.limit);
-  }
-
-  return ref;
 }
 
 /**
@@ -112,34 +78,3 @@ export function addDefaultArgs(
 }
 
 process.env.FORCE_COLOR = 'true';
-
-/**
- * Check to see if the provided value is a promise object
- * @param valToCheck - Value to be checked for Promise qualities
- * @returns Whether or not provided value is a promise
- */
-export function isPromise(valToCheck: any): boolean {
-  return valToCheck && typeof valToCheck.then === 'function';
-}
-
-/**
- * Escape shell command arguments and join them to a single string
- * @param a - List of arguments to escape
- * @returns Command string with arguments escaped
- */
-export function shellescape(a: string[]): string {
-  const ret: string[] = [];
-
-  a.forEach(s => {
-    if (/[^A-Za-z0-9_/:=-]/.test(s)) {
-      // eslint-disable-line no-useless-escape
-      s = `'${s.replace(/'/g, "'\\''")}'`; // eslint-disable-line no-param-reassign
-      s = s // eslint-disable-line no-param-reassign
-        .replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
-        .replace(/\\'''/g, "\\'"); // remove non-escaped single-quote if there are enclosed between 2 escaped
-    }
-    ret.push(s);
-  });
-
-  return ret.join(' ');
-}

--- a/test/unit/buildRtdbCommand.spec.ts
+++ b/test/unit/buildRtdbCommand.spec.ts
@@ -16,6 +16,86 @@ describe('buildRtdbCommand', () => {
       expect(buildRtdbCommand(Cypress, action, actionPath))
         .to.equal(`${firebasePath} database:${action} /${actionPath}`)
     })
+    
+    it('supports orderByChild (--order-by flag for firebase-tools)', () => {
+      const actionPath = 'some/path'
+      const action = 'get'
+      const orderByChild = 'asdf'
+      expect(buildRtdbCommand(Cypress, action, actionPath, { orderByChild  }))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} --order-by ${orderByChild}`)
+    })
+
+    it('supports orderByKey (--order-by-key flag for firebase-tools)', () => {
+      const actionPath = 'some/path'
+      const action = 'get'
+      expect(buildRtdbCommand(Cypress, action, actionPath, { orderByKey: true  }))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} --order-by-key`)
+    })
+
+    it('supports orderByValue (--order-by-value flag for firebase-tools)', () => {
+      const actionPath = 'some/path'
+      const action = 'get'
+      expect(buildRtdbCommand(Cypress, action, actionPath, { orderByValue: true  }))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} --order-by-value`)
+    })
+
+    it('supports startAt (--start-at flag for firebase-tools)', () => {
+      const actionPath = 'some/path'
+      const action = 'get'
+      const startAt = 'asdf'
+      expect(buildRtdbCommand(Cypress, action, actionPath, { startAt  }))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} --start-at ${startAt}`)
+    })
+
+    it('supports endAt (--end-at flag for firebase-tools)', () => {
+      const actionPath = 'some/path'
+      const action = 'get'
+      const endAt = 'asdf'
+      expect(buildRtdbCommand(Cypress, action, actionPath, { endAt }))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} --end-at ${endAt}`)
+    })
+
+    it('supports equalTo (--equal-to flag for firebase-tools)', () => {
+      const actionPath = 'some/path'
+      const action = 'get'
+      const equalTo = 'asdf'
+      expect(buildRtdbCommand(Cypress, action, actionPath, { equalTo }))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} --equal-to ${equalTo}`)
+    })
+
+    it('supports instance (--instance flag for firebase-tools)', () => {
+      const actionPath = 'some/path'
+      const action = 'get'
+      const instance = 'asdf'
+      expect(buildRtdbCommand(Cypress, action, actionPath, { instance }))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} --instance ${instance}`)
+    })
+
+    it('supports limitToLast (--limitToLast flag for firebase-tools)', () => {
+      const actionPath = 'some/path'
+      const action = 'get'
+      const limitToLast = 'asdf'
+      expect(buildRtdbCommand(Cypress, action, actionPath, { limitToLast }))
+        .to.equal(`${firebasePath} database:${action} /${actionPath} --order-by-key --limit-to-last ${limitToLast}`)
+    })
+
+    describe('supports limitToFirst (--limitToFirst flag for firebase-tools)', () => {
+      it('as a boolean (defaults to 1 with order by key)', () => {
+        const actionPath = 'some/path'
+        const action = 'get'
+        const limitToFirst = 1
+        expect(buildRtdbCommand(Cypress, action, actionPath, { limitToFirst }))
+          .to.equal(`${firebasePath} database:${action} /${actionPath} --order-by-key --limit-to-first ${limitToFirst}`)
+      })
+
+      it('as a string', () => {
+        const actionPath = 'some/path'
+        const action = 'get'
+        const limitToFirst = 'asdf'
+        expect(buildRtdbCommand(Cypress, action, actionPath, { limitToFirst }))
+          .to.equal(`${firebasePath} database:${action} /${actionPath} --order-by-key --limit-to-first ${limitToFirst}`)
+      })
+    })
   });
 
   describe('set', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,10 +1984,10 @@ firebase-admin@^8.6.1:
     "@google-cloud/firestore" "^2.0.0"
     "@google-cloud/storage" "^3.0.2"
 
-firebase-tools-extra@0.2.0-alpha:
-  version "0.2.0-alpha"
-  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.2.0-alpha.tgz#6cd4716e9693f5a7da24b3a49dcda0b93cf174bc"
-  integrity sha512-RSt9CZdf422T0EWyttV7btG3nfGYuUW5leAk2R+RpHVDcmhtrVemSYDdvdxTcz40jMpkxt98NKaHJNAyjU+d8Q==
+firebase-tools-extra@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.2.0.tgz#86ea500fdbe9c6d8b5882f7ae390099cb95020f9"
+  integrity sha512-QPu3uxXjZGRq5Y9WynxPd+rq5pVJZlPDGcvjdc12JTq34e0Vf65CX0fSkWMjrbgN3iyyezJTwcCd0L3vc9H/9g==
   dependencies:
     firebase-admin "^8.6.1"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,6 +1239,13 @@ debug@3.2.6, debug@^3.0.0, debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^4.0.1, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -1275,7 +1282,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -1963,10 +1970,10 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-firebase-admin@^8.4.0, firebase-admin@^8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-8.5.0.tgz#99d1a007edb1689c3012eca64968c93846d5e292"
-  integrity sha512-rvgCj5Z1iFOT6K6uW37VRl4PKNpAcBFu/FIQ4Nl5bFnqbHSxf+QxzsqdsUtIxdqZU1yh2DTs2t+s5qORx/T9+g==
+firebase-admin@^8.6.1:
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-8.6.1.tgz#b4fe5133a759a06afe06d1bf8dee6e302514a304"
+  integrity sha512-efheZmT7w9POLfJGBl0JoIUTRe1OMAWMAs/PgM0CZw+F8AM9C29UTAr+XgzRYMzY3llaDWu7zLGQ0Zl4E9jybg==
   dependencies:
     "@firebase/database" "^0.5.1"
     "@types/node" "^8.0.53"
@@ -1977,19 +1984,19 @@ firebase-admin@^8.4.0, firebase-admin@^8.5.0:
     "@google-cloud/firestore" "^2.0.0"
     "@google-cloud/storage" "^3.0.2"
 
-firebase-tools-extra@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.1.1.tgz#cb52b478c4918e5df4c86360974d081058756639"
-  integrity sha512-kQya/H8mNk9i8miClCrWy/wm4J5LZFsKMlSdEhfC8mm7Aq5CTdKlkTskBQxDpOdyJyorKN3BdwQAV7kRCyCDrA==
+firebase-tools-extra@0.2.0-alpha:
+  version "0.2.0-alpha"
+  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.2.0-alpha.tgz#6cd4716e9693f5a7da24b3a49dcda0b93cf174bc"
+  integrity sha512-RSt9CZdf422T0EWyttV7btG3nfGYuUW5leAk2R+RpHVDcmhtrVemSYDdvdxTcz40jMpkxt98NKaHJNAyjU+d8Q==
   dependencies:
-    firebase-admin "^8.4.0"
+    firebase-admin "^8.6.1"
     lodash "^4.17.15"
     yargs "^14.0.0"
 
-firebase-tools@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/firebase-tools/-/firebase-tools-7.3.1.tgz#fe3e1a87aac5c3a5cb532672fa8a430d91947820"
-  integrity sha512-nAbY42SzgM4AUYqOkuRR1ESkBYTJRkw+CGwzDlNgno+Q3P6ZSsMnrfpFf1Uy+KYOln05h4Kr3MObecgLkVav1g==
+firebase-tools@^7.6.1:
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/firebase-tools/-/firebase-tools-7.6.1.tgz#4198e973ef515513d56cc2d3ebf2e23b2bc0f3ad"
+  integrity sha512-FLsNZ8ZHvqaM94Mh31w8ppm3i0cfh7FzdUqINFqUKr7EwgLzg4f0TyAz59XwDd42rkzFk/ZPAlaiv6yCaIUIZA==
   dependencies:
     JSONStream "^1.2.1"
     archiver "^3.0.0"
@@ -2027,6 +2034,7 @@ firebase-tools@^7.3.1:
     semver "^5.0.3"
     superstatic "^6.0.1"
     tar "^4.3.0"
+    tcp-port-used "^1.0.1"
     tmp "0.0.33"
     universal-analytics "^0.4.16"
     update-notifier "^2.5.0"
@@ -2626,6 +2634,11 @@ inquirer@~6.3.1:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+ip-regex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
 ipaddr.js@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
@@ -2787,6 +2800,15 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.1.tgz#8ac355644840921ce435d94f05d3a94634d3481a"
+  integrity sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==
+  dependencies:
+    deep-is "^0.1.3"
+    ip-regex "^2.1.0"
+    is-url "^1.2.2"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -4739,6 +4761,14 @@ tar@^4.3.0:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
+
+tcp-port-used@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.1.tgz#46061078e2d38c73979a2c2c12b5a674e6689d70"
+  integrity sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==
+  dependencies:
+    debug "4.1.0"
+    is2 "2.0.1"
 
 teeny-request@^5.2.1:
   version "5.2.1"


### PR DESCRIPTION
* fix(callirestore): handle `String` instance responses from `cy.exec`
* fix(utils): remove unused commands
* fix(callRtdb): pass correct argument for `orderByChild` in rtdb command
* feat(callRtdb): add support for other query arguments in get call (including `orderByKey`, `orderByValue`, `limitToFirst`, `limitToLast`, `startAt`, `endAt`, and `instance`)
* chore(deps): update to [`firebase-tools-extra` v0.2.0](https://github.com/prescottprue/firebase-tools-extra/releases/tag/v0.2.0)