### PR TITLE
fix(docs): note that firebase-tools should be installed locally instead of globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you are interested in what drove the need for this checkout [the why section]
 
 **Note:** These instructions assume your tests are in the `cypress` folder (cypress' default). See the [folders section below](#folders) for more info about other supported folders.
 
-1. Make sure you have `firebase-tools` installed (globally or within project). It is used to call to database when using `cy.callRtdb` and `cy.callFirestore`.
+1. Make sure you have `firebase-tools` installed (globally and within project). It is used to call to database when using `cy.callRtdb` and `cy.callFirestore`.
 1. Install using `npm i cypress-firebase --save-dev`
 1. Add the following to the `scripts` section of your `package.json`:
 


### PR DESCRIPTION
Hi there, thanks for your project to let us have a chance to test firebase project with cypress.
You have done a great innovation job! I will continually follow your new footage. 

For this PR, I am just want to mention something about ```firebase-tools``` installation.

The case is that I failed to perform DELETE to Firestore using your ```cy.callFirestore```, and I found the error message in cypress is something like we haven’t ```firebase``` in ```node_modules/.bin```, we know that this folder contains some of the files as a link(symbol) of our packages installed in project(automatically) or globally(maybe we need do some extra job). 

Then after my observation, I found the ```firebase``` symbol is related to ```firebase-tools```, so each time we perform DELETE, we need this file in our ```node_modules/.bin```.

After that, I tried to reinstall  ```firebase-tools``` again globally, and I still can’t see that symbol created in that folder.

Then I tried to install it locally(in the project), and it appeared, and finally problem solved.

So I suggest to change the document to guide the user to install ```firebase-tools``` in project and globally.
I think it has no harm to this in both ways.

Cheers.