### PR TITLE
v0.5.1

### DIFF
--- a/cmds/open.js
+++ b/cmds/open.js
@@ -1,16 +1,12 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-/**
- * run commander component
- * To use add require('../cmds/run.js')(program) to your commander.js based node executable before program.parse
- */
 const chalk = require('chalk');
 const { runCommand } = require('../lib/node-utils');
 const logger = require('../lib/logger');
 
 /**
  * @name open
- * @description Create test environment config then open Cypress Test Runner
- * @param {String} envName
+ * Create test environment config then open Cypress Test Runner
+ * @param {string} program - Commander program
  */
 module.exports = function open(program) {
   program

--- a/cmds/run.js
+++ b/cmds/run.js
@@ -6,8 +6,8 @@ const createTestEnvFile = require('../lib/createTestEnvFile').default;
 
 /**
  * @name run
- * @description Build test configuration file then run cypress run command
- * @param {String} envName
+ * Build test configuration file then run cypress run command
+ * @param {string} program - Commander program
  */
 module.exports = function run(program) {
   program

--- a/index.d.ts
+++ b/index.d.ts
@@ -319,12 +319,6 @@ declare module "node-utils" {
      */
     export function withEnvPrefix(varNameRoot: string, envName?: string): string;
     /**
-     * Get cypress folder path from cypress.json config file or fallback to
-     * default folder path ('cypress')
-     * @returns Path of folder containing cypress folders like "integration"
-     */
-    export function getCypressFolderPath(): string;
-    /**
      * Get path to cypress config file
      * @returns Path to cypress config file
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -300,12 +300,24 @@ declare module "node-utils" {
      */
     export function readJsonFile(filePath: string): any;
     /**
+     * Get environment slug
+     * @returns Environment slug
+     */
+    export function getEnvironmentSlug(): string;
+    /**
      * Get prefix for current environment based on environment vars available
      * within CI. Falls back to staging (i.e. STAGE)
      * @param envName - Environment option
      * @returns Environment prefix string
      */
     export function getEnvPrefix(envName?: string): string;
+    /**
+     * Create a variable name string with environment prefix (i.e. STAGE_SERVICE_ACCOUNT)
+     * @param varNameRoot - Root of environment variable name
+     * @param envName - Environment option
+     * @returns Environment var name with prefix
+     */
+    export function withEnvPrefix(varNameRoot: string, envName?: string): string;
     /**
      * Get cypress folder path from cypress.json config file or fallback to
      * default folder path ('cypress')
@@ -348,9 +360,6 @@ declare module "node-utils" {
     export interface RunCommandOptions {
         command: string;
         args: string[];
-        beforeMsg?: string;
-        successMsg?: string;
-        errorMsg?: string;
         pipeOutput?: boolean;
     }
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Utilities to help testing Firebase projects with Cypress.",
   "main": "lib/index.js",
   "module": "lib/index.js",
@@ -33,7 +33,7 @@
     "commander": "^4.0.1",
     "figures": "^3.1.0",
     "firebase-admin": "^8.8.0",
-    "firebase-tools-extra": "0.2.1",
+    "firebase-tools-extra": "0.3.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,35 +101,12 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.4.7.tgz#792a0f117185e42ec5a247f6bedc94a921711110"
   integrity sha512-4LnhDYsUhgxMBnCfQtWvrmMy9XxeZo059HiRbpt3ufdpUcZZOBDOouQdjkODwHLhcnNrB7LeyiqYpS2jrLT8Mw==
 
-"@firebase/app-types@0.x":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.4.3.tgz#80d2b6e5ee43ac99892329ab02301ee7ed82da45"
-  integrity sha512-VU5c+ZjejvefLVH4cjiX3Hy1w9HYMv7TtZ1tF9ZmOqT4DSIU1a3VISWoo8///cGGffr5IirMO+Q/WZLI4p8VcA==
-
-"@firebase/database-types@0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.4.3.tgz#4ee4ada5544f3629fb451e216da8f917a80ae8cd"
-  integrity sha512-21yCiJA2Tyt6dJYwWeB69MwoawBu5UWNtP6MAY0ugyRBHVdjAMHMYalPxCjZ46LAmhfim0+i8NXRadOFVS3hUA==
-  dependencies:
-    "@firebase/app-types" "0.x"
-
 "@firebase/database-types@0.4.7":
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.4.7.tgz#9fc82b3895fc096f073e37dd66d6e5b32f233a54"
   integrity sha512-7UHZ0n6aj3sR5W4HsU18dysHMSIS6348xWTMypoA0G4mORaQSuleCSL6zJLaCosarDEojnncy06yW69fyFxZtA==
   dependencies:
     "@firebase/app-types" "0.4.7"
-
-"@firebase/database@^0.5.1":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-0.5.2.tgz#9f480c64f7a16569ae8cf18ed82b22acf0ea0885"
-  integrity sha512-LnXKRE1AmjlS+iRF7j8vx+Ni8x85CmLP5u5Pw5rDKhKLn2eTR1tJKD937mUeeGEtDHwR1rrrkLYOqRR2cSG3hQ==
-  dependencies:
-    "@firebase/database-types" "0.4.3"
-    "@firebase/logger" "0.1.24"
-    "@firebase/util" "0.2.27"
-    faye-websocket "0.11.3"
-    tslib "1.10.0"
 
 "@firebase/database@^0.5.11":
   version "0.5.12"
@@ -142,22 +119,10 @@
     faye-websocket "0.11.3"
     tslib "1.10.0"
 
-"@firebase/logger@0.1.24":
-  version "0.1.24"
-  resolved "https://registry.yarnpkg.com/@firebase/logger/-/logger-0.1.24.tgz#770468c9f6c910c0db6008f7dccad88bb1df06d6"
-  integrity sha512-wPwhWCepEjWiTIqeC9U+7Hcw4XwezKPdXmyXbYSPiWNDcVekNgMPkntwSK+/2ufJO/1nMwAL2n6fL12oQG/PpQ==
-
 "@firebase/logger@0.1.30":
   version "0.1.30"
   resolved "https://registry.yarnpkg.com/@firebase/logger/-/logger-0.1.30.tgz#44079d93113e3567a9f32f35b22097fcde08248d"
   integrity sha512-smlUDMiOLZD7kgBzcdSbICCvDblglq0X3NUcvV450kjZxOOPY1jPK54Qd/m0qbKrRlHWwr83reJGcPQDVBXd+A==
-
-"@firebase/util@0.2.27":
-  version "0.2.27"
-  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-0.2.27.tgz#6adac01023af835ed44379534b09fd1399f6f469"
-  integrity sha512-kFlbWNX1OuLfHrDXZ5QLmNNiLtMyxzbBgMo1DY1tXMjKK1AMYsHnyjInA8esvO0SCDp5XN3Pt9EDlhY4sRiLsw==
-  dependencies:
-    tslib "1.10.0"
 
 "@firebase/util@0.2.33":
   version "0.2.33"
@@ -180,17 +145,6 @@
     google-auth-library "^5.0.0"
     retry-request "^4.0.0"
     teeny-request "^5.2.1"
-
-"@google-cloud/firestore@^2.0.0":
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/@google-cloud/firestore/-/firestore-2.2.9.tgz#1ee31cd439c66a7d5683ffbd582540af19f6a73b"
-  integrity sha512-75MdgTJeZ3TR4EsoKVT09N6PoyFlX4xDtcOe+oH2b63XfOA3/turoJTUplhsiVRGTP9SoEMHOl9kfYa4oepdmg==
-  dependencies:
-    bun "^0.0.12"
-    deep-equal "^1.0.1"
-    functional-red-black-tree "^1.0.1"
-    google-gax "^1.1.2"
-    through2 "^3.0.0"
 
 "@google-cloud/firestore@^2.6.0":
   version "2.6.0"
@@ -248,33 +202,6 @@
     p-defer "^3.0.0"
     protobufjs "^6.8.1"
 
-"@google-cloud/storage@^3.0.2":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-3.2.1.tgz#6701fbc91b95304e0da88c0f193b1800c9ba4159"
-  integrity sha512-129EwPGej6bXzY1u5nja2aeMDew6DIHaJn7ZV6nteQ74LQQSNv2jKrqTlyhndBsAwpuwQAxeghPTCoFT/H8Frg==
-  dependencies:
-    "@google-cloud/common" "^2.1.1"
-    "@google-cloud/paginator" "^2.0.0"
-    "@google-cloud/promisify" "^1.0.0"
-    arrify "^2.0.0"
-    compressible "^2.0.12"
-    concat-stream "^2.0.0"
-    date-and-time "^0.9.0"
-    duplexify "^3.5.0"
-    extend "^3.0.2"
-    gaxios "^2.0.1"
-    gcs-resumable-upload "^2.0.0"
-    hash-stream-validation "^0.2.1"
-    mime "^2.2.0"
-    mime-types "^2.0.8"
-    onetime "^5.1.0"
-    p-limit "^2.2.0"
-    pumpify "^2.0.0"
-    snakeize "^0.1.0"
-    stream-events "^1.0.1"
-    through2 "^3.0.0"
-    xdg-basedir "^4.0.0"
-
 "@google-cloud/storage@^4.1.2":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-4.1.3.tgz#f570ed06fcf51834a4761d01aaa3fb81570f32f6"
@@ -309,13 +236,6 @@
   integrity sha512-r1nDOEEiYmAsVYBaS4DPPqdwPOXPw7YhVOnnpPdWhlNtKbYzPash6DqWTTza9gBiYMA5d2Wiq6HzrPqsRaP4yA==
   dependencies:
     semver "^6.2.0"
-
-"@grpc/grpc-js@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-0.5.2.tgz#8e39876033749e1611fe9fa181d9535077805abe"
-  integrity sha512-NE1tP/1AF6BqhLdILElnF7aOBfoky+4ZOdZU/0NmKo2d+9F9QD8zGoElpBk/5BfyQZ3u1Zs+wFbDOFpVUzDx1w==
-  dependencies:
-    semver "^6.0.0"
 
 "@grpc/proto-loader@^0.5.1":
   version "0.5.2"
@@ -1595,11 +1515,6 @@ date-and-time@^0.11.0:
   resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.11.0.tgz#1e22b61533af303953d79cc8c5e92e228fc5e4d2"
   integrity sha512-VyzhHurex4wlg9oMszn7O+kxHchphWjzDn7Mv0WfkFKI6hSNOQePpTBFGsnRakvLNzQKXqPBAVV8DOxUGtUxqA==
 
-date-and-time@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.9.0.tgz#1524579e56dc07675c640b41735a7665c0659240"
-  integrity sha512-4JybB6PbR+EebpFx/KyR5Ybl+TcdXMLIJkyYsCx3P4M4CWGMuDyFF19yh6TyasMAIF5lrsgIxiSHBXh2FFc7Fg==
-
 debug@2.6.9, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2393,20 +2308,6 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-firebase-admin@^8.7.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-8.7.0.tgz#10be179f76ca6725f322ab7252812a92f1b879c0"
-  integrity sha512-mAp/58ZHbZHGPlSe8JDyELOT6DAWGUv9N3pA6d+Sg5RS5H3I1xGnKkhXK9BMJsejUfA3mwOqFPMLD4yso7aFxw==
-  dependencies:
-    "@firebase/database" "^0.5.1"
-    "@types/node" "^8.0.53"
-    dicer "^0.3.0"
-    jsonwebtoken "8.1.0"
-    node-forge "0.7.4"
-  optionalDependencies:
-    "@google-cloud/firestore" "^2.0.0"
-    "@google-cloud/storage" "^3.0.2"
-
 firebase-admin@^8.8.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-8.8.0.tgz#6fbe5a8353d13d61dee504a54e18b7ef82d0d8a8"
@@ -2421,12 +2322,12 @@ firebase-admin@^8.8.0:
     "@google-cloud/firestore" "^2.6.0"
     "@google-cloud/storage" "^4.1.2"
 
-firebase-tools-extra@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.2.1.tgz#fd671bb3111c6150283a87c780795d0edebfeab8"
-  integrity sha512-TsMruWXElP1Fh7tiSSXk+6ibsAVfm+Pkw9AuZDqHk15qxAEhsRsnMecHKCQvOH79/FaS3J5xvQdJqiavhiaFWA==
+firebase-tools-extra@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.3.0.tgz#8de211806b86325cdc3bddf3611298cf763c8fbe"
+  integrity sha512-gLzka/NSgcLiZKhfINWkgu3/JV/dpyJBfaYvRK8VhaWyBTtsEctlztWjy7TGsXuLXbC033Jk1sni9Mm4PkIo5A==
   dependencies:
-    firebase-admin "^8.7.0"
+    firebase-admin "^8.8.0"
     lodash "^4.17.15"
     yargs "^14.2.0"
 
@@ -2651,18 +2552,6 @@ gcp-metadata@^3.2.0:
     gaxios "^2.1.0"
     json-bigint "^0.3.0"
 
-gcs-resumable-upload@^2.0.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/gcs-resumable-upload/-/gcs-resumable-upload-2.2.4.tgz#c81f58c456cbc6c14c71f12c51779de454d1ccad"
-  integrity sha512-UqoGRLImof+6DRv/7QnMGP3ot+RKhsIS2dVziGFe+ajFDW0cnit7xYyViFA99utDQB0RD+fSqKBkYwNXX3Y42w==
-  dependencies:
-    abort-controller "^3.0.0"
-    configstore "^5.0.0"
-    gaxios "^2.0.0"
-    google-auth-library "^5.0.0"
-    pumpify "^2.0.0"
-    stream-events "^1.0.4"
-
 gcs-resumable-upload@^2.2.4:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/gcs-resumable-upload/-/gcs-resumable-upload-2.3.1.tgz#5fa7c3035108bba7a2f95435377ad92acdbae656"
@@ -2819,25 +2708,6 @@ google-auto-auth@^0.7.2:
     google-auth-library "^0.10.0"
     request "^2.79.0"
 
-google-gax@^1.1.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-1.5.2.tgz#996cf70778667cc22befbeae4b8a9d76fce0fabb"
-  integrity sha512-NceyDzlw4mQz6qH3bDIuRtfDAZKehM96QpnPPJ3Hur7FA/gPzpzboUYwhfP6q5obSP4LuSSDhI/76Fu51/ljtg==
-  dependencies:
-    "@grpc/grpc-js" "^0.5.2"
-    "@grpc/proto-loader" "^0.5.1"
-    abort-controller "^3.0.0"
-    duplexify "^3.6.0"
-    google-auth-library "^5.0.0"
-    is-stream-ended "^0.1.4"
-    lodash.at "^4.6.0"
-    lodash.has "^4.5.2"
-    node-fetch "^2.6.0"
-    protobufjs "^6.8.8"
-    retry-request "^4.0.0"
-    semver "^6.0.0"
-    walkdir "^0.4.0"
-
 google-gax@^1.7.5:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-1.11.1.tgz#9be67c762f25445a6d8d410207f2c6e180b3b947"
@@ -2991,13 +2861,6 @@ has@^1.0.1, has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
-
-hash-stream-validation@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz#ecc9b997b218be5bb31298628bb807869b73dcd1"
-  integrity sha1-7Mm5l7IYvluzEphii7gHhptz3NE=
-  dependencies:
-    through2 "^2.0.0"
 
 hash-stream-validation@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
* fix(createTestEnvFile): add support for loading project id from `ci.createConfig` in `.firebaserc` (used by firebase-ci)
* fix(callFirestore): dynamic project name handling in Firestore emulator ([firebase-tools-extra v0.3.0](https://github.com/prescottprue/firebase-tools-extra/releases/tag/v0.3.0)) - #73