### PR TITLE
v0.10.1

### DIFF
--- a/examples/basic/cypress/integration/Projects.spec.js
+++ b/examples/basic/cypress/integration/Projects.spec.js
@@ -1,24 +1,16 @@
 describe('Projects View', () => {
   describe('when authenticated', () => {
     before(() => {
-      // Login using custom token
-      cy.log('Calling login')
+      // Use cy.setRtdb() to set projects created by authed user
+      cy.callRtdb('push', 'projects', { name: 'project 1' }, { withMeta: true })
+      cy.callRtdb('push', 'projects', { name: 'project 3' }, { withMeta: true })
       cy.login(Cypress.env('TEST_UID'));
-      // TODO: Use cy.setRtdb() to set projects created by authed user
-      // cy.callFirestore('add', 'projects', { name: 'project 1'})
-      // cy.callRtdb('set', 'projects/asdf123', { name: 'project 1'})
       // Go to home page
       cy.visit('/');
     });
 
-    after(() => {
-      // TODO: Use cy.setRtdb() to set projects created by authed user
-      // cy.callRtdb('remove')
-    })
-
     it('Shows projects if logged in', () => {
       cy.get('[data-test=projects]').should('exist')
     });
-  })
-
+  });
 });

--- a/examples/basic/cypress/support/commands.js
+++ b/examples/basic/cypress/support/commands.js
@@ -4,21 +4,31 @@ import 'firebase/database';
 import 'firebase/firestore';
 import { attachCustomCommands } from 'cypress-firebase';
 
+
 const fbConfig = {
   apiKey: "AIzaSyCTUERDM-Pchn_UDTsfhVPiwM4TtNIxots",
   authDomain: "redux-firebasev3.firebaseapp.com",
-  // databaseURL: "https://redux-firebasev3.firebaseio.com",
-  datbaseURL: `http://localhost:9000?ns=redux-firebasev3`,
+  databaseURL: "https://redux-firebasev3.firebaseio.com",
   projectId: "redux-firebasev3",
   storageBucket: "redux-firebasev3.appspot.com",
   messagingSenderId: "823357791673"
 }
 
-window.fbInstance = firebase.initializeApp(fbConfig);
+// Emulate RTDB if Env variable is passed
+const rtdbEmulatorHost = Cypress.env('FIREBASE_DATABASE_EMULATOR_HOST')
+if (rtdbEmulatorHost) {
+  fbConfig.databaseURL = `http://${rtdbEmulatorHost}?ns=redux-firebasev3`
+}
 
-firebase.firestore().settings({
-  host: 'localhost:8080',
-  ssl: false
-})
+firebase.initializeApp(fbConfig);
+
+// Emulate Firestore if Env variable is passed
+const firestoreEmulatorHost = Cypress.env('FIRESTORE_EMULATOR_HOST')
+if (firestoreEmulatorHost) {
+  firebase.firestore().settings({
+    host: firestoreEmulatorHost,
+    ssl: false
+  })
+}
 
 attachCustomCommands({ Cypress, cy, firebase })

--- a/examples/basic/firebase.json
+++ b/examples/basic/firebase.json
@@ -1,0 +1,20 @@
+{
+  "hosting": {
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  },
+  "database": {
+    "rules": "database.rules.json"
+  },
+  "emulators": {
+    "database": {
+      "port": 9000
+    }
+  }
+}

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -3,13 +3,14 @@
   "version": "0.1.0",
   "scripts": {
     "start": "react-scripts start",
-    "emulate": "cross-env REACT_APP_USE_DB_EMULATORS=true yarn start",
+    "dev": "cross-env REACT_APP_USE_DB_EMULATORS=true yarn start",
+    "emulators": "firebase emulators:start --only database",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "build:testConfig": "cypress-firebase createTestEnvFile",
-    "test": "npm run build:testConfig && cross-env CYPRESS_baseUrl=http://localhost:3000 cypress run",
-    "test:ui": "npm run build:testConfig && cross-env CYPRESS_baseUrl=http://localhost:3000 cypress open",
-    "test:emulate": "npm run build:testConfig && cross-env CYPRESS_baseUrl=http://localhost:3000 cypress open"
+    "test": "cross-env CYPRESS_baseUrl=http://localhost:3000 cypress run",
+    "test:open": "cross-env CYPRESS_baseUrl=http://localhost:3000 cypress open",
+    "test:emulate": "cross-env FIREBASE_DATABASE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.database.port)\" yarn test:open"
   },
   "dependencies": {
     "firebase": "^7.8.0",
@@ -18,7 +19,7 @@
     "react-dom": "^16.12.0"
   },
   "devDependencies": {
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.0",
     "cypress": "^4.0.1",
     "cypress-firebase": "*",
     "eslint-plugin-cypress": "^2.0.1",

--- a/examples/basic/src/App.js
+++ b/examples/basic/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import initFirebase from './initFirebase'
 import RTDBProjects from './RTDBProjects'
-import FirestoreProjects from './FirestoreProjects'
+// import FirestoreProjects from './FirestoreProjects'
 import './App.css';
 
 initFirebase()
@@ -12,8 +12,12 @@ function App() {
       <header className="App-header">
         <h2>Data From RTDB</h2>
         <RTDBProjects />
-        <h2>Data From Firestore</h2>
-        <FirestoreProjects />        
+        {/* Skipped since emulated Firestore does not
+            currently work with Cypress.
+            See: https://github.com/cypress-io/cypress/issues/6350
+        */}
+        {/* <h2>Data From Firestore</h2>
+        <FirestoreProjects />         */}
       </header>
     </div>
   )

--- a/examples/basic/yarn.lock
+++ b/examples/basic/yarn.lock
@@ -4446,7 +4446,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^5.1.3, cross-env@^5.2.0:
+cross-env@^5.1.3:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
   integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
@@ -4454,7 +4454,14 @@ cross-env@^5.1.3, cross-env@^5.2.0:
     cross-spawn "^6.0.5"
     is-windows "^1.0.0"
 
-cross-spawn@7.0.1, cross-spawn@^7.0.0:
+cross-env@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.0.tgz#5a3b2ddce51ec713ea58f2fb79ce22e65b4f5479"
+  integrity sha512-rV6M9ldNgmwP7bx5u6rZsTbYidzwvrwIYZnT08hSGLcQCcggofgFW+sNe7IhA1SRauPS0QuLbbX+wdNtpqE5CQ==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@7.0.1, cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Utilities to help testing Firebase projects with Cypress.",
   "main": "lib/index.js",
   "module": "lib/index.js",
@@ -33,7 +33,7 @@
     "commander": "^4.1.0",
     "figures": "^3.1.0",
     "firebase-admin": "^8.9.2",
-    "firebase-tools-extra": "0.5.0",
+    "firebase-tools-extra": "0.5.1",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,10 +2489,10 @@ firebase-admin@^8.9.2:
     "@google-cloud/firestore" "^3.0.0"
     "@google-cloud/storage" "^4.1.2"
 
-firebase-tools-extra@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.5.0.tgz#160cbb59d30eec14c2b2bfd5d83990b8cf3023f2"
-  integrity sha512-DxIIkYRmRiADP1HT+ZrstDZ0MwOWg5jHnDpntyHuPoPxTukgG5ZzRA+ZWIlNO8X0MqXkoCNhBdr5Sle/9KGC4A==
+firebase-tools-extra@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.5.1.tgz#ba3e3c6e79c113caba25b0b0993fde954477ec24"
+  integrity sha512-C7z7Z1YXOJ0Iv577LpLGktaLSdx+UC4gmXa3N1Ej/WxMmhgpEFVCIw0hKSq+tOeUNWvejUa2ZE6XxSkvtPKtkQ==
   dependencies:
     firebase-admin "^8.9.2"
     lodash "^4.17.15"


### PR DESCRIPTION
* fix(deps): update to [firebase-tools-extra v0.5.1](https://github.com/prescottprue/firebase-tools-extra/releases/tag/v0.5.1) to fix potential command timeouts when using emulator
* chore(examples): update basic example to have npm scripts for testing against database emulator
* chore(docs): move auth config into its own section of README
* chore(docs): update README to no longer include `window.fbInstance`