### PR TITLE
v0.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,114 @@ describe('Test firestore', () => {
 
 ## Recipes
 
+### Using Database Emulators
+
+1. Add the following to the `scripts` section of your `package.json`:
+
+    ```json
+    "emulators": "firebase emulators:start --only database,firestore",
+    "test": "cross-env CYPRESS_baseUrl=http://localhost:3000 cypress run",
+    "test:open": "cross-env CYPRESS_baseUrl=http://localhost:3000 cypress open",
+    "test:emulate": "cross-env CYPRESS_FIREBASE_DATABASE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.database.port)\" CYPRESS_FIRESTORE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.firestore.port)\" yarn test:open"
+    ```
+1. Add support in your application for connecting to the emulators:
+
+    ```js
+    const shouldUseEmulator = window.location.hostname === 'localhost' // or other logic to determine when to use
+    // Emulate RTDB
+    if (shouldUseEmulator) {
+      console.log('Using RTDB emulator')
+      fbConfig.databaseURL = `http://localhost:9000?ns=${fbConfig.projectId}`
+    }
+
+    // Initialize Firebase instance
+    firebase.initializeApp(fbConfig)
+
+    // Emulate Firestore
+    if (shouldUseEmulator) {
+      console.log('Using Firestore emulator')
+      const firestoreSettings = {
+        host: 'localhost:8080',
+        ssl: false,
+      };
+
+      // Pass long polling setting to Firestore when running in Cypress
+      if (window.Cypress) {
+        // Needed for Firestore support in Cypress (see https://github.com/cypress-io/cypress/issues/6350)
+        firestoreSettings.experimentalForceLongPolling = true;
+      }
+
+      firebase.firestore().settings(firestoreSettings)
+    }
+    ```
+
+1. Make sure you also have matching init logic in `cypress/support/commands.js` or `cypress/support/index.js`:
+    
+    ```js
+    import firebase from 'firebase/app';
+    import 'firebase/auth';
+    import 'firebase/database';
+    import 'firebase/firestore';
+    import { attachCustomCommands } from 'cypress-firebase';
+
+    const fbConfig = {
+      // Your Firebase Config
+    }
+
+    // Emulate RTDB if Env variable is passed
+    const rtdbEmulatorHost = Cypress.env('FIREBASE_DATABASE_EMULATOR_HOST')
+    if (rtdbEmulatorHost) {
+      fbConfig.databaseURL = `http://${rtdbEmulatorHost}?ns=${fbConfig.projectId}`
+    }
+
+    firebase.initializeApp(fbConfig);
+
+    // Emulate Firestore if Env variable is passed
+    const firestoreEmulatorHost = Cypress.env('FIRESTORE_EMULATOR_HOST')
+    if (firestoreEmulatorHost) {
+      firebase.firestore().settings({
+        host: firestoreEmulatorHost,
+        ssl: false
+      })
+    }
+
+    attachCustomCommands({ Cypress, cy, firebase })
+    ```
+
+1. Start emulators using `npm run emulators`
+1. In another terminal window, boot up the application using `npm start`
+1. In another terminal window, boot up tests with emulator settings using `npm run test:emulate`
+
+**NOTE**: If you are using react-scripts or other environment management, you can use environment variables to pass settings into your app:
+
+```js
+const { REACT_APP_FIREBASE_DATABASE_EMULATOR_HOST, REACT_APP_FIRESTORE_EMULATOR_HOST } = process.env
+// Emulate RTDB if REACT_APP_FIREBASE_DATABASE_EMULATOR_HOST exists in environment
+if (REACT_APP_FIREBASE_DATABASE_EMULATOR_HOST) {
+  console.log('Using RTDB emulator')
+  fbConfig.databaseURL = `http://${REACT_APP_FIREBASE_DATABASE_EMULATOR_HOST}?ns=${fbConfig.projectId}`
+}
+
+// Initialize Firebase instance
+firebase.initializeApp(fbConfig)
+
+// Emulate RTDB if REACT_APP_FIRESTORE_EMULATOR_HOST exists in environment
+if (REACT_APP_FIRESTORE_EMULATOR_HOST) {
+  console.log('Using Firestore emulator')
+  const firestoreSettings = {
+    host: REACT_APP_FIRESTORE_EMULATOR_HOST,
+    ssl: false,
+  };
+
+  if (window.Cypress) {
+    // Needed for Firestore support in Cypress (see https://github.com/cypress-io/cypress/issues/6350)
+    firestoreSettings.experimentalForceLongPolling = true;
+  }
+
+  firebase.firestore().settings(firestoreSettings)
+}
+```
+
 ### Generate JWT Before Run
 
 1. Add the following to the `scripts` section of your `package.json`:
@@ -288,12 +396,12 @@ describe('Test firestore', () => {
     "test": "npm run build:testConfig && cypress run",
     "test:open": "npm run build:testConfig && cypress open",
     ```
+
 1. Add your config info to your environment variables (for CI) or `cypress.env.json` when running locally (make sure this is in you `.gitignore`)
   
     ```js
     {
-      "TEST_UID": "<- uid of the user you want to test as ->",
-      "FIREBASE_API_KEY": "<- browser apiKey of your project ->"
+      "TEST_UID": "<- uid of the user you want to test as ->"
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -281,14 +281,16 @@ describe('Test firestore', () => {
 
 ### Using Database Emulators
 
+1. Install cross-env for cross system environment variable support: `npm i --save-dev cross-env`
 1. Add the following to the `scripts` section of your `package.json`:
 
     ```json
     "emulators": "firebase emulators:start --only database,firestore",
     "test": "cross-env CYPRESS_baseUrl=http://localhost:3000 cypress run",
     "test:open": "cross-env CYPRESS_baseUrl=http://localhost:3000 cypress open",
-    "test:emulate": "cross-env CYPRESS_FIREBASE_DATABASE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.database.port)\" CYPRESS_FIRESTORE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.firestore.port)\" yarn test:open"
+    "test:emulate": "cross-env FIREBASE_DATABASE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.database.port)\" FIRESTORE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.firestore.port)\" yarn test:open"
     ```
+
 1. Add support in your application for connecting to the emulators:
 
     ```js
@@ -353,9 +355,9 @@ describe('Test firestore', () => {
     attachCustomCommands({ Cypress, cy, firebase })
     ```
 
-1. Start emulators using `npm run emulators`
-1. In another terminal window, boot up the application using `npm start`
-1. In another terminal window, boot up tests with emulator settings using `npm run test:emulate`
+1. Start emulators: `npm run emulators`
+1. In another terminal window, start the application: `npm start`
+1. In another terminal window, open test runner with emulator settings: `npm run test:emulate`
 
 **NOTE**: If you are using react-scripts or other environment management, you can use environment variables to pass settings into your app:
 

--- a/examples/basic/firebase.json
+++ b/examples/basic/firebase.json
@@ -15,6 +15,9 @@
   "emulators": {
     "database": {
       "port": 9000
+    },
+    "firestore": {
+      "port": 8080
     }
   }
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,7 +10,7 @@
     "build:testConfig": "cypress-firebase createTestEnvFile",
     "test": "cross-env CYPRESS_baseUrl=http://localhost:3000 cypress run",
     "test:open": "cross-env CYPRESS_baseUrl=http://localhost:3000 cypress open",
-    "test:emulate": "cross-env FIREBASE_DATABASE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.database.port)\" yarn test:open"
+    "test:emulate": "cross-env FIREBASE_DATABASE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.database.port)\" FIRESTORE_EMULATOR_HOST=\"localhost:$(cat firebase.json | jq .emulators.firestore.port)\" yarn test:open"
   },
   "dependencies": {
     "firebase": "^7.8.0",
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.0",
-    "cypress": "^4.0.1",
+    "cypress": "^4.0.2",
     "cypress-firebase": "*",
     "eslint-plugin-cypress": "^2.0.1",
     "firebase-tools": "^7.12.1",

--- a/examples/basic/src/initFirebase.js
+++ b/examples/basic/src/initFirebase.js
@@ -27,10 +27,16 @@ export default function getFirebaseInstance(initialState, history) {
     firebase.initializeApp(fbConfig)
     if (shouldUseEmulator) { // or window.location.hostname === 'localhost' if you want
       console.log('Using Firestore emulator')
-      firebase.firestore().settings({
+      const firestoreSettings = {
         host: 'localhost:8080',
-        ssl: false
-      })
+        ssl: false,
+      };
+  
+      if (window.Cypress) {
+        // Needed for Firestore support in Cypress (see https://github.com/cypress-io/cypress/issues/6350)
+        firestoreSettings.experimentalForceLongPolling = true;
+      }
+      firebase.firestore().settings(firestoreSettings)
     }
     firebaseInstance = firebase
   }

--- a/examples/basic/yarn.lock
+++ b/examples/basic/yarn.lock
@@ -4792,10 +4792,10 @@ cypress-firebase@*:
     firebase-tools-extra "^0.0.7"
     lodash "^4.17.11"
 
-cypress@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.0.1.tgz#815da77c8e2528501b9af2e8d12cfcaec8c9dde7"
-  integrity sha512-P+cSwc5yE+1hIkWwJzpsiSQthKmzkFeFz2ySejSrJJ6FiXoL8pp0vr1cyWp+75KT4nqL9IYt1GMrHp+mVmvocA==
+cypress@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.0.2.tgz#ede194d7bc73fb449f8de553c9e1db4ca15309ef"
+  integrity sha512-WRzxOoSd+TxyXKa7Zi9orz3ii5VW7yhhVYstCU+EpOKfPan9x5Ww2Clucmy4H/W0GHUYAo7GYFZRD33ZCSNBQA==
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
     "@cypress/xvfb" "1.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-firebase",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Utilities to help testing Firebase projects with Cypress.",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "commander": "^4.1.0",
     "figures": "^3.1.0",
     "firebase-admin": "^8.9.2",
-    "firebase-tools-extra": "0.5.1",
+    "firebase-tools-extra": "0.5.2",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -332,6 +332,9 @@ export default function attachCustomCommands(
           (typeof stdout === 'string' || stdout instanceof String)
         ) {
           try {
+            if (stdout === '') {
+              return null;
+            }
             return JSON.parse(
               stdout instanceof String ? stdout.toString() : stdout,
             );

--- a/src/buildFirestoreCommand.ts
+++ b/src/buildFirestoreCommand.ts
@@ -77,10 +77,13 @@ export default function buildFirestoreCommand(
       // Call to firebase-tools-extra if using emulator since firebase-tools does not support
       // calling emulator through database commands. See this issue for
       // more detail: https://github.com/firebase/firebase-tools/issues/1957
-      const commandPath = Cypress.env('FIRESTORE_EMULATOR_HOST')
+      const isUsingEmulator = !!Cypress.env('FIRESTORE_EMULATOR_HOST');
+      const commandPath = isUsingEmulator
         ? FIREBASE_EXTRA_PATH
         : FIREBASE_TOOLS_BASE_COMMAND;
-      return `${commandPath} firestore:${action} ${actionPath}${deleteArgsStr}`;
+      return `${commandPath} firestore${
+        !isUsingEmulator ? ':' : ' '
+      }${action} ${actionPath}${deleteArgsStr}`;
     }
     case 'get': {
       return `${FIREBASE_EXTRA_PATH} firestore ${action} ${actionPath}`;

--- a/test/unit/buildFirestoreCommand.spec.ts
+++ b/test/unit/buildFirestoreCommand.spec.ts
@@ -106,7 +106,7 @@ describe('buildFirestoreCommand', () => {
             recursive: true,
           },
         ),
-      ).to.equal(`npx firebase-extra firestore:delete ${actionPath} -y -r`);
+      ).to.equal(`npx firebase-extra firestore delete ${actionPath} -y -r`);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,10 +2506,10 @@ firebase-admin@^8.9.2:
     "@google-cloud/firestore" "^3.0.0"
     "@google-cloud/storage" "^4.1.2"
 
-firebase-tools-extra@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.5.1.tgz#ba3e3c6e79c113caba25b0b0993fde954477ec24"
-  integrity sha512-C7z7Z1YXOJ0Iv577LpLGktaLSdx+UC4gmXa3N1Ej/WxMmhgpEFVCIw0hKSq+tOeUNWvejUa2ZE6XxSkvtPKtkQ==
+firebase-tools-extra@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/firebase-tools-extra/-/firebase-tools-extra-0.5.2.tgz#2f18de24f7eef00e08ad447eb8fc84cebfb52eaa"
+  integrity sha512-fwmXyVeISFwQebf92KxrAa2mdDp+B43fFbdsAwfJr14DZ5I1O5IGPc0w8J09Km8NarQuoiuDBKKDuR1ADgSjag==
   dependencies:
     firebase-admin "^8.9.2"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,6 +428,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@tootallnate/once@1":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.0.0.tgz#9c13c2574c92d4503b005feca8f2e16cc1611506"
+  integrity sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==
+
 "@types/chai@*":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.3.tgz#419477a3d5202bad19e14c787940a61dc9ea6407"
@@ -596,6 +601,18 @@ agent-base@4, agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
+agent-base@6:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.0.tgz#5d0101f19bbfaed39980b22ae866de153b93f09a"
+  integrity sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==
+  dependencies:
+    debug "4"
+
 aggregate-error@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
@@ -760,7 +777,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-argv@^0.0.2:
+argv@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
   integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
@@ -1286,15 +1303,15 @@ clone@^1.0.2:
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
 codecov@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.1.tgz#f39fc49413445555f81f8e3ca5730992843b4517"
-  integrity sha512-IUJB6WG47nWK7o50etF8jBadxdMw7DmoQg05yIljstXFBGB6clOZsIj6iD4P82T2YaIU3qq+FFu8K9pxgkCJDQ==
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.5.tgz#d73ce62e8a021f5249f54b073e6f2d6a513f172a"
+  integrity sha512-v48WuDMUug6JXwmmfsMzhCHRnhUf8O3duqXvltaYJKrO1OekZWpB/eH6iIoaxMl8Qli0+u3OxptdsBOYiD7VAQ==
   dependencies:
-    argv "^0.0.2"
-    ignore-walk "^3.0.1"
-    js-yaml "^3.13.1"
-    teeny-request "^3.11.3"
-    urlgrey "^0.4.4"
+    argv "0.0.2"
+    ignore-walk "3.0.3"
+    js-yaml "3.13.1"
+    teeny-request "6.0.1"
+    urlgrey "0.4.4"
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -1665,17 +1682,17 @@ debug@3.2.6, debug@^3.0.0, debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
   integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -3138,6 +3155,15 @@ http-proxy-agent@^2.1.0:
     agent-base "4"
     debug "3.1.0"
 
+http-proxy-agent@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -3162,6 +3188,14 @@ https-proxy-agent@^3.0.0:
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
+
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
 
 husky@^4.2.1:
   version "4.2.1"
@@ -3191,7 +3225,7 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
-ignore-walk@^3.0.1:
+ignore-walk@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
   integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
@@ -5795,13 +5829,15 @@ tcp-port-used@^1.0.1:
     debug "4.1.0"
     is2 "2.0.1"
 
-teeny-request@^3.11.3:
-  version "3.11.3"
-  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-3.11.3.tgz#335c629f7645e5d6599362df2f3230c4cbc23a55"
-  integrity sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==
+teeny-request@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-6.0.1.tgz#9b1f512cef152945827ba7e34f62523a4ce2c5b0"
+  integrity sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==
   dependencies:
-    https-proxy-agent "^2.2.1"
+    http-proxy-agent "^4.0.0"
+    https-proxy-agent "^4.0.0"
     node-fetch "^2.2.0"
+    stream-events "^1.0.5"
     uuid "^3.3.2"
 
 teeny-request@^5.2.1:
@@ -6097,7 +6133,7 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-urlgrey@^0.4.4:
+urlgrey@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
   integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=


### PR DESCRIPTION
* fix(firestore): correctly return `null` for empty `get` responses
* fix(firestore): correctly call `delete` within Firestore emulator
* fix(test): update firestore emulator delete test
* chore(docs): add a recipe to README about using with emulator
* chore(examples): update basic example to support Firestore emulator
* chore(deps-dev): bump codecov from 3.6.1 to 3.6.5 (#91) 