### PR TITLE
chore(docs): improve getting started instructions to handle case of never having run Cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you are interested in what drove the need for this checkout [the why section]
    };
    ```
 
-1. To confirm things are working, add a cypress-firebase custom command (such as `cy.callFirestore`) to one of your tests:
+1. To confirm things are working, create a new test file (`cypress/integration/examples/test_hello_world.js`) adding a test that uses the cypress-firebase custom command (`cy.callFirestore`):
 
    ```js
    describe("Some Test", () => {
@@ -82,8 +82,8 @@ If you are interested in what drove the need for this checkout [the why section]
      });
    });
    ```
-
-1. Look in the `test_hello_world` collection of your Firestore instance (or whichever collection you write in your test) to confirm that a document was added
+1. From the root of your project, start Cypress with the command `./node_modules/cypress/bin/cypress open`.  In the Cypress window, click your new test (`test_hello_world.js`) to run it.
+1. Look in your Firestore instance and see the `test_hello_world` collection to confirm that a document was added.
 1. Pat yourself on the back, you are all setup to access Firebase/Firestore from within your tests!
 
 #### Auth

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you are interested in what drove the need for this checkout [the why section]
      });
    });
    ```
-1. From the root of your project, start Cypress with the command `./node_modules/cypress/bin/cypress open`.  In the Cypress window, click your new test (`test_hello_world.js`) to run it.
+1. From the root of your project, start Cypress with the command `$(npm bin)/cypress open`.  In the Cypress window, click your new test (`test_hello_world.js`) to run it.
 1. Look in your Firestore instance and see the `test_hello_world` collection to confirm that a document was added.
 1. Pat yourself on the back, you are all setup to access Firebase/Firestore from within your tests!
 


### PR DESCRIPTION
Minor tweaks to make startup instructions more accessible to Cypress newbies.