### PR TITLE
fix(docs): use correct checking logic in callFirestore example

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ describe("Test firestore", () => {
       age: 8,
     });
     cy.callFirestore("get", `testCollection/${TEST_UID}`).then((r) => {
-      cy.wrap(r[0]).its("id").should("equal", TEST_UID);
-      cy.wrap(r[0]).its("data.age").should("equal", mockAge);
+      cy.log("get returned: ", r);
+      cy.wrap(r).its("data.age").should("equal", mockAge);
     });
     cy.log("Ended test");
   });


### PR DESCRIPTION
`callFirestore("get", ...)` appears to return a single instance, not an array of instances.  `r[0]` is undefined.  `r.age` and `r.name` exist.  There does not appear to be a clear way to get `r.id` (though the caller knows the ID since they used it in the "get" call . . .)

If there is a way to get the metadata from a `callFirestore("get", ...)` or other approach, then it would be GREAT to add that to the example.