### PR TITLE
fix(docs): use correct method name in callFirestore docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ level. If using delete, auth is through FIREBASE_TOKEN since firebase-tools is u
 
 ##### Parameters
 
-- `action` **[String][11]** The action type to call with (set, push, update, remove)
+- `action` **[String][11]** The action type to call with (set, push, update, delete)
 - `actionPath` **[String][11]** Path within RTDB that action should be applied
 - `dataOrOptions` **[String][11]** Data for write actions or options for get action
 - `options` **[Object][12]** Options


### PR DESCRIPTION
In firestore, it is "delete".

I recommend getting a "remove" example added to the RTDB section.