### PR TITLE
chore(docs): clarify usage with other plugins in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,14 @@ If you are interested in what drove the need for this checkout [the why section]
    const cypressFirebasePlugin = require("cypress-firebase").plugin;
 
    module.exports = (on, config) => {
-     // Pass on function, config, and admin instance. Returns extended config
-     return cypressFirebasePlugin(on, config, admin);
+     // Pass on function, config, and admin instance
+     cypressFirebasePlugin(on, config, admin)
+     
+     // add other plugins/tasks to be registered here
+     
+     // IMPORTANT to return the config object
+     // with the any changed environment variables
+     return config
    };
    ```
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,11 @@ If you are interested in what drove the need for this checkout [the why section]
    const cypressFirebasePlugin = require("cypress-firebase").plugin;
 
    module.exports = (on, config) => {
-     // Pass on function, config, and admin instance
-     cypressFirebasePlugin(on, config, admin)
-     
-     // add other plugins/tasks to be registered here
-     
-     // IMPORTANT to return the config object
-     // with the any changed environment variables
-     return config
+     const extendedConfig = cypressFirebasePlugin(on, config, admin)
+
+     // Add other plugins/tasks such as code coverage here
+
+     return extendedConfig
    };
    ```
 


### PR DESCRIPTION
Minor tweak to config to make it clearer that cypress-firebase plugin config is "just another plugin", as there might be other plugins/tasks to be registered.  For example, see https://github.com/prescottprue/cypress-firebase/issues/129 .