### PR TITLE
Fix the "Initialized app" message

### DIFF
--- a/src/firebase-utils.ts
+++ b/src/firebase-utils.ts
@@ -108,7 +108,7 @@ export function initializeFirebase(
     }
     /* eslint-disable no-console */
     console.log(
-      `cypress-firebase: Initialized app with database url "${fbConfig.projectId}"`,
+      `cypress-firebase: Initialized app with database url "${fbConfig.databaseURL}"`,
     );
     /* eslint-enable no-console */
     return fbInstance;


### PR DESCRIPTION
### Description
The message says "database url" but actually logged `projectId`
