### PR TITLE
feat(core): add support for passing app instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ If you are interested in what drove the need for this checkout [the why section]
    - `CYPRESS_TEST_UID` - UID of your test user
    - `SERVICE_ACCOUNT` - service account object
 
+### Named app support
+
+When using a custom app name or running more than one firebase instance in your app:
+
+```js
+const namedApp = firebase.initializeApp(fbConfig, "app_name");
+
+attachCustomCommands({ Cypress, cy, firebase, app: namedApp });
+```
+
 ## Docs
 
 ### Custom Cypress Commands

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare module "attachCustomCommands" {
         Cypress: any;
         cy: any;
         firebase: any;
+        app?: any;
     }
     /**
      * Action for Firestore

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -8,6 +8,7 @@ export interface AttachCustomCommandParams {
   Cypress: any;
   cy: any;
   firebase: any;
+  app?: any;
 }
 
 /**
@@ -113,51 +114,51 @@ export interface CallRtdbOptions {
    * @see https://firebase.google.com/docs/reference/js/firebase.database.Query#startat
    */
   startAt?:
-    | number
-    | string
-    | boolean
-    | null
-    | [number | string | boolean | null, string];
+  | number
+  | string
+  | boolean
+  | null
+  | [number | string | boolean | null, string];
   /**
    * Creates a Query with the specified starting point.
    * @see https://firebase.google.com/docs/reference/js/firebase.database.Query#startafter
    */
   startAfter?:
-    | number
-    | string
-    | boolean
-    | null
-    | [number | string | boolean | null, string];
+  | number
+  | string
+  | boolean
+  | null
+  | [number | string | boolean | null, string];
   /**
    * End results after <val, key> (based on specified ordering)
    * @see https://firebase.google.com/docs/reference/js/firebase.database.Query#endbefore
    */
   endBefore?:
-    | number
-    | string
-    | boolean
-    | null
-    | [number | string | boolean | null, string];
+  | number
+  | string
+  | boolean
+  | null
+  | [number | string | boolean | null, string];
   /**
    * End results at <val> (based on specified ordering)
    * @see https://firebase.google.com/docs/reference/js/firebase.database.Query#endat
    */
   endAt?:
-    | number
-    | string
-    | boolean
-    | null
-    | [number | string | boolean | null, string];
+  | number
+  | string
+  | boolean
+  | null
+  | [number | string | boolean | null, string];
   /**
    * Restrict results to <val> (based on specified ordering)
    * @see https://firebase.google.com/docs/reference/js/firebase.database.Query#equalto
    */
   equalTo?:
-    | number
-    | string
-    | boolean
-    | null
-    | [number | string | boolean | null, string];
+  | number
+  | string
+  | boolean
+  | null
+  | [number | string | boolean | null, string];
 }
 
 // Add custom commands to the existing Cypress interface
@@ -276,19 +277,21 @@ function getTypeStr(value: any): TypeStr {
 /**
  * @param firebase - firebase instance
  * @param customToken - Custom token to use for login
+ * @param app - firebase app
  * @returns Promise which resolves with the user auth object
  */
 function loginWithCustomToken(
   firebase: any,
   customToken: string,
+  app: any,
 ): Promise<any> {
   return new Promise((resolve, reject): any => {
-    firebase.auth().onAuthStateChanged((auth: any) => {
+    firebase.auth(app).onAuthStateChanged((auth: any) => {
       if (auth) {
         resolve(auth);
       }
     });
-    firebase.auth().signInWithCustomToken(customToken).catch(reject);
+    firebase.auth(app).signInWithCustomToken(customToken).catch(reject);
   });
 }
 
@@ -314,7 +317,9 @@ export default function attachCustomCommands(
   context: AttachCustomCommandParams,
   options?: CustomCommandOptions,
 ): void {
-  const { Cypress, cy, firebase } = context;
+  const { Cypress, cy, firebase, app } = context;
+
+  const defaultApp = app || firebase.app(); // select default  app
 
   /**
    * Login to Firebase auth as a user with either a passed uid or the TEST_UID
@@ -334,8 +339,8 @@ export default function attachCustomCommands(
       }
       // Resolve with current user if they already exist
       if (
-        firebase.auth().currentUser &&
-        userUid === firebase.auth().currentUser.uid
+        firebase.auth(defaultApp).currentUser &&
+        userUid === firebase.auth(defaultApp).currentUser.uid
       ) {
         cy.log('Authed user already exists, login complete.');
         return undefined;
@@ -347,7 +352,7 @@ export default function attachCustomCommands(
       return cy
         .task('createCustomToken', { uid: userUid, customClaims })
         .then((customToken: string) =>
-          loginWithCustomToken(firebase, customToken),
+          loginWithCustomToken(firebase, customToken, app),
         );
     },
   );
@@ -367,12 +372,12 @@ export default function attachCustomCommands(
           resolve: (value?: any) => void,
           reject: (reason?: any) => void,
         ): any => {
-          firebase.auth().onAuthStateChanged((auth: any) => {
+          firebase.auth(defaultApp).onAuthStateChanged((auth: any) => {
             if (!auth) {
               resolve();
             }
           });
-          firebase.auth().signOut().catch(reject);
+          firebase.auth(defaultApp).signOut().catch(reject);
         },
       ),
   );


### PR DESCRIPTION
In our Cypress application we use multiple named Firebase applications. This PR is to add support for others with the same set of circumstances.

Tested with:
cypress 8.7.0
firebase 8.10.0
firebase-admin 10.0.0