### PR TITLE
fix(peer-deps): add v10 to supported versions for firebase-admin peer dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepare": "husky install && yarn clean && yarn build"
   },
   "peerDependencies": {
-    "firebase-admin": "^8 || ^9"
+    "firebase-admin": "^8 || ^9 || ^10"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^1.3.1",


### PR DESCRIPTION
Support firebase-admin@10 alongside 8 and 9. This PR allows npm users to avoid having to force install (using `npm install --legacy-peer-deps`) on newer versions of npm