### PR TITLE
fix(firestore): handle firestore date nested in object within array

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -125,12 +125,16 @@ function getDataWithTimestampsAndGeoPoints(
       };
     }
     const value = Array.isArray(currData)
-      ? currData.map((dataItem) =>
-          convertValueToTimestampOrGeoPointIfPossible(
+      ? currData.map((dataItem) => {
+          const result = convertValueToTimestampOrGeoPointIfPossible(
             dataItem,
             firestoreStatics,
-          ),
-        )
+          );
+
+          return result.constructor === Object
+            ? getDataWithTimestampsAndGeoPoints(result, firestoreStatics)
+            : result;
+        })
       : convertValueToTimestampOrGeoPointIfPossible(currData, firestoreStatics);
 
     return {

--- a/test/unit/tasks.spec.ts
+++ b/test/unit/tasks.spec.ts
@@ -429,7 +429,13 @@ describe('tasks', () => {
             'update',
             PROJECT_PATH,
             { statics: admin.firestore },
-            { time: { nested: stringifiedServerTimestamp } },
+            {
+              time: {
+                nested: stringifiedServerTimestamp,
+                arrayNested: [stringifiedServerTimestamp],
+                mapInArrayNested: [{ nested: stringifiedServerTimestamp }],
+              },
+            },
           );
 
           const resultSnap = await projectFirestoreRef.get();
@@ -440,6 +446,22 @@ describe('tasks', () => {
           );
           expect(resultSnap.data()).to.have.nested.property(
             'time.nested._nanoseconds',
+            correctTimestamp._nanoseconds,
+          );
+          expect(resultSnap.data()).to.have.nested.property(
+            'time.arrayNested[0]._seconds',
+            correctTimestamp._seconds,
+          );
+          expect(resultSnap.data()).to.have.nested.property(
+            'time.arrayNested[0]._nanoseconds',
+            correctTimestamp._nanoseconds,
+          );
+          expect(resultSnap.data()).to.have.nested.property(
+            'time.mapInArrayNested[0].nested._seconds',
+            correctTimestamp._seconds,
+          );
+          expect(resultSnap.data()).to.have.nested.property(
+            'time.mapInArrayNested[0].nested._nanoseconds',
             correctTimestamp._nanoseconds,
           );
           /* eslint-enable no-underscore-dangle */


### PR DESCRIPTION
### Description

Fixed a bug that firestore does not save as a date if the date exists in the map in the array.

### Screenshots (if appropriate)
