### PR TITLE
fix: support firebase-admin v11 and higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepare": "husky install && yarn clean && yarn build"
   },
   "peerDependencies": {
-    "firebase-admin": "^8 || ^9 || ^10"
+    "firebase-admin": ">=8"
   },
   "devDependencies": {
     "@commitlint/cli": "16.3.0",


### PR DESCRIPTION
### Description
* Adds support for firebase-admin v11 and higher by updating `peerDependencies` to `>8`

### Screenshots (if appropriate)
