### PR TITLE
fix(callFirestore): prevent coercing 0 values  (#1039)

### DIFF
--- a/src/firebase-utils.ts
+++ b/src/firebase-utils.ts
@@ -209,10 +209,11 @@ export function isDocPath(slashPath: string): boolean {
 }
 
 /**
- *
- * @param ref
- * @param whereSetting
- * @param firestoreStatics
+ * Apply where setting to reference
+ * @param ref - Reference
+ * @param whereSetting - Where options
+ * @param firestoreStatics - Firestore statics
+ * @returns Refere with where applied
  */
 export function applyWhere(
   ref: firestore.CollectionReference | firestore.Query,

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -88,10 +88,18 @@ export function convertValueToTimestampOrGeoPointIfPossible(
     return firestoreStatics.FieldValue.delete();
   }
   /* eslint-enable no-underscore-dangle */
-  if (typeof dataVal !== 'undefined' && typeof dataVal.seconds === 'number' && typeof dataVal.nanoseconds === 'number') {
+  if (
+    typeof dataVal !== 'undefined' &&
+    typeof dataVal.seconds === 'number' &&
+    typeof dataVal.nanoseconds === 'number'
+  ) {
     return new firestoreStatics.Timestamp(dataVal.seconds, dataVal.nanoseconds);
   }
-  if (typeof dataVal !== 'undefined' && typeof dataVal.latitude === 'number' && typeof dataVal.longitude === 'number') {
+  if (
+    typeof dataVal !== 'undefined' &&
+    typeof dataVal.latitude === 'number' &&
+    typeof dataVal.longitude === 'number'
+  ) {
     return new firestoreStatics.GeoPoint(dataVal.latitude, dataVal.longitude);
   }
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -90,6 +90,7 @@ export function convertValueToTimestampOrGeoPointIfPossible(
   /* eslint-enable no-underscore-dangle */
   if (
     typeof dataVal !== 'undefined' &&
+    dataVal !== null &&
     typeof dataVal.seconds === 'number' &&
     typeof dataVal.nanoseconds === 'number'
   ) {
@@ -97,6 +98,7 @@ export function convertValueToTimestampOrGeoPointIfPossible(
   }
   if (
     typeof dataVal !== 'undefined' &&
+    dataVal !== null &&
     typeof dataVal.latitude === 'number' &&
     typeof dataVal.longitude === 'number'
   ) {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -88,16 +88,10 @@ export function convertValueToTimestampOrGeoPointIfPossible(
     return firestoreStatics.FieldValue.delete();
   }
   /* eslint-enable no-underscore-dangle */
-  if (
-    typeof (dataVal && dataVal.seconds) === 'number' &&
-    typeof (dataVal && dataVal.nanoseconds) === 'number'
-  ) {
+  if (typeof dataVal !== 'undefined' && typeof dataVal.seconds === 'number' && typeof dataVal.nanoseconds === 'number') {
     return new firestoreStatics.Timestamp(dataVal.seconds, dataVal.nanoseconds);
   }
-  if (
-    typeof (dataVal && dataVal.latitude) === 'number' &&
-    typeof (dataVal && dataVal.longitude) === 'number'
-  ) {
+  if (typeof dataVal !== 'undefined' && typeof dataVal.latitude === 'number' && typeof dataVal.longitude === 'number') {
     return new firestoreStatics.GeoPoint(dataVal.latitude, dataVal.longitude);
   }
 

--- a/test/unit/tasks.spec.ts
+++ b/test/unit/tasks.spec.ts
@@ -297,8 +297,8 @@ describe('tasks', () => {
         expect(result).to.have.property('some', extraVal.some);
       });
 
-      it('sets a document with null data', async () => {
-        const extraVal = { some: 'other', another: null };
+      it('sets a document with object containing null and 0', async () => {
+        const extraVal = { some: 'other', another: null, zeroField: 0 };
         await tasks.callFirestore(
           adminApp,
           'set',
@@ -311,6 +311,7 @@ describe('tasks', () => {
         expect(result).to.have.property('name', testProject.name);
         expect(result).to.have.property('some', extraVal.some);
         expect(result).to.have.property('another', null);
+        expect(result).to.have.property('zeroField', 0);
       });
 
       describe('with timestamps', () => {


### PR DESCRIPTION
### Description
Original PR here by @michaeldawson:  https://github.com/prescottprue/cypress-firebase/pull/1039

Created this PR to iron our lint issues and handling of `null` in an object. Updated tests to include confirming of `0` value
### Screenshots (if appropriate)
