### PR TITLE
fix(ci): lock semantic to 18 to fix release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,6 +75,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          semantic_version: ^18
           branches: |
             [
               '+([0-9])?(.{+([0-9]),x}).x',


### PR DESCRIPTION
### Description
Fixes https://github.com/prescottprue/cypress-firebase/actions/runs/6018384481/job/16326480087#step:12:29
### Screenshots (if appropriate)
![image](https://github.com/prescottprue/cypress-firebase/assets/2992224/eddd7d2d-995b-40a4-9993-a76ddf892a23)
