### PR TITLE
feat: more auth functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@
 
 0 dependency plugin which adds [custom cypress commands](https://docs.cypress.io/api/cypress-api/custom-commands.html#Syntax) for interactions with Firebase:
 
-- [cy.login][1]
-- [cy.logout][4]
-- [cy.callRtdb][6]
-- [cy.callFirestore][9]
+- [cy.createUserWithClaims][createUserWClaims]
+- [cy.login][login]
+- [cy.loginWithEmailAndPassword][loginEmail]
+- [cy.logout][logout]
+- [cy.deleteAllAuthUsers][delAllUsers]
+- [cy.callRtdb][callRtdb]
+- [cy.callFirestore][callFirestore]
+- [cy.\[authFunction\]][authFunctions]
 
 If you are interested in what drove the need for this checkout [the why section](#why)
 
@@ -180,16 +184,48 @@ attachCustomCommands({ Cypress, cy, firebase, app: namedApp });
 
 #### Table of Contents
 
-- [cy.login][1]
-  - [Examples][2]
-- [cy.logout][4]
-  - [Examples][5]
-- [cy.callRtdb][6]
-  - [Parameters][7]
-  - [Examples][8]
-- [cy.callFirestore][9]
-  - [Parameters][10]
-  - [Examples][11]
+- [cy.createUserWithClaims][createUserWClaims]
+  - [Parameters][createUserWClaims-params]
+  - [Examples][createUserWClaims-ex]
+- [cy.login][login]
+  - [Parameters][login-params]
+  - [Examples][login-ex]
+- [cy.loginWithEmailAndPassword][loginEmail]
+  - [Parameters][loginEmail-params]
+  - [Examples][loginEmail-ex]
+- [cy.logout][logout]
+  - [Parameters][logout-params]
+  - [Examples][logout-ex]
+- [cy.deleteAllAuthUsers][delAllUsers]
+  - [Parameters][delAllUsers-params]
+  - [Examples][delAllUsers-ex]
+- [cy.callRtdb][callRtdb]
+  - [Parameters][callRtdb-params]
+  - [Examples][callRtdb-ex]
+- [cy.callFirestore][callFirestore]
+  - [Parameters][callFirestore-params]
+  - [Examples][callFirestore-ex]
+- [cy.\[authFunction\]][authFunctions]
+  - [Parameters][authFunctions-params]
+  - [Examples][authFunctions-ex]
+
+#### cy.createUserWithClaims
+
+Command to create a user and give the user custom claims in one command.
+
+##### Parameters
+
+- `properties` **[CreateRequest][firebase-createrequest]** The properties of the new user
+- `customClaims` **[object][mdn-object] | [null][mdn-null]** Optional custom claims to be set, or null to remove custom claims
+- `tenantId` **[string][mdn-string]** Optional ID of tenant used for multi-tenancy. Can also be set with environment variable TEST_TENANT_ID
+
+##### Examples
+
+```javascript
+const uid = '123SomeUid';
+const claims = { role: 'Admin' };
+cy.createUserWithClaims(uid, claims);
+```
 
 #### cy.login
 
@@ -197,22 +233,28 @@ Login to Firebase using custom auth token.
 
 To specify a tenant ID, either pass the ID as a parameter to `cy.login`, or set it as environment variable `TEST_TENANT_ID`. Read more about [Firebase multi-tenancy](https://cloud.google.com/identity-platform/docs/multi-tenancy-authentication).
 
+##### Parameters
+
+- `uid` **[string][mdn-string]** UID of user to login as. Can also be set with environment variable TEST_UID
+- `customClaims` **[string][mdn-string]** Optional custom claims to attach to the custom token
+- `tenantId` **[string][mdn-string]** Optional ID of tenant used for multi-tenancy. Can also be set with environment variable TEST_TENANT_ID
+
 ##### Examples
 
-Loading `TEST_UID` automatically from Cypress env:
+_Loading `TEST_UID` automatically from Cypress env_
 
 ```javascript
 cy.login();
 ```
 
-Passing a UID
+_Passing a UID_
 
 ```javascript
 const uid = '123SomeUid';
 cy.login(uid);
 ```
 
-Passing a tenant ID
+_Passing a tenant ID_
 
 ```javascript
 const uid = '123SomeUid';
@@ -220,14 +262,82 @@ const tenantId = '123SomeTenantId';
 cy.login(uid, undefined, tenantId);
 ```
 
+#### cy.loginWithEmailAndPassword
+
+Login to Firebase using an email and password account.
+
+##### Parameters
+
+- `email` **[string][mdn-string]** Email of user to login as. Can also be set with environment variable TEST_EMAIL
+- `password` **[string][mdn-string]** Password of user to login as. Can also be set with environment variable TEST_PASSWORD
+- `extraInfo` **[CreateRequest][firebase-createrequest]** Optional additional CreateRequest parameters except for email and password
+- `tenantId` **[string][mdn-string]** Optional ID of tenant used for multi-tenancy. Can also be set with environment variable TEST_TENANT_ID
+
+##### Examples
+
+_Loading `TEST_EMAIL` and `TEST_PASSWORD` automatically from Cypress env_
+
+```javascript
+cy.loginWithEmailAndPassword();
+```
+
+_Passing an email and password_
+
+```javascript
+const email = 'some@user.com';
+const psswd = 'password123';
+cy.loginWithEmailAndPassword(email, psswd);
+```
+
+_Passing a tenant ID_
+
+```javascript
+const email = 'some@user.com';
+const psswd = 'password123';
+const tenantId = '123SomeTenantId';
+cy.loginWithEmailAndPassword(email, psswd, undefined, tenantId);
+```
+
 #### cy.logout
 
 Log out of Firebase instance
+
+##### Parameters
+
+- `tenantId` **[string][mdn-string]** Optional ID of tenant used for multi-tenancy. Can also be set with environment variable TEST_TENANT_ID
 
 ##### Examples
 
 ```javascript
 cy.logout();
+```
+
+_Passing a tenant ID_
+
+```javascript
+const tenantId = '123SomeTenantId';
+cy.logout(tenantId);
+```
+
+#### cy.deleteAllAuthUsers
+
+Command to recursively delete all firebase auth users. The firebase deleteUsers function (cy.authDeleteUsers) can only remove a maximum amount of users at a time. This command calls the deleteUsers function recursively for every pageToken returned by the previous iteration.
+
+##### Parameters
+
+- `tenantId` **[string][mdn-string]** Optional ID of tenant used for multi-tenancy. Can also be set with environment variable TEST_TENANT_ID
+
+##### Examples
+
+```javascript
+cy.deleteAllAuthUsers();
+```
+
+_Passing a tenant ID_
+
+```javascript
+const tenantId = '123SomeTenantId';
+cy.deleteAllAuthUsers(tenantId);
 ```
 
 #### cy.callRtdb
@@ -236,17 +346,17 @@ Call Real Time Database path with some specified action such as `set`, `update` 
 
 ##### Parameters
 
-- `action` **[String][11]** The action type to call with (set, push, update, remove)
-- `actionPath` **[String][11]** Path within RTDB that action should be applied
-- `options` **[object][12]** Options
-  - `options.limitToFirst` **[number|boolean][13]** Limit to the first `<num>` results. If true is passed than query is limited to last 1 item.
-  - `options.limitToLast` **[number|boolean][13]** Limit to the last `<num>` results. If true is passed than query is limited to last 1 item.
-  - `options.orderByKey` **[boolean][13]** Order by key name
-  - `options.orderByValue` **[boolean][13]** Order by primitive value
-  - `options.orderByChild` **[string][11]** Select a child key by which to order results
-  - `options.equalTo` **[string][11]** Restrict results to `<val>` (based on specified ordering)
-  - `options.startAt` **[string][11]** Start results at `<val>` (based on specified ordering)
-  - `options.endAt` **[string][11]** End results at `<val>` (based on specified ordering)
+- `action` **[string][mdn-string]** The action type to call with (set, push, update, remove)
+- `actionPath` **[string][mdn-string]** Path within RTDB that action should be applied
+- `options` **[object][mdn-object]** Options
+  - `options.limitToFirst` **[number][mdn-number]|[boolean][mdn-boolean]** Limit to the first `<num>` results. If true is passed than query is limited to last 1 item.
+  - `options.limitToLast` **[number][mdn-number]|[boolean][mdn-boolean]** Limit to the last `<num>` results. If true is passed than query is limited to last 1 item.
+  - `options.orderByKey` **[boolean][mdn-boolean]** Order by key name
+  - `options.orderByValue` **[boolean][mdn-boolean]** Order by primitive value
+  - `options.orderByChild` **[string][mdn-string]** Select a child key by which to order results
+  - `options.equalTo` **[string][mdn-string]** Restrict results to `<val>` (based on specified ordering)
+  - `options.startAt` **[string][mdn-string]** Start results at `<val>` (based on specified ordering)
+  - `options.endAt` **[string][mdn-string]** End results at `<val>` (based on specified ordering)
 
 ##### Examples
 
@@ -326,19 +436,19 @@ level.
 
 ##### Parameters
 
-- `action` **[String][11]** The action type to call with (set, push, update, delete)
-- `actionPath` **[String][11]** Path within Firestore that action should be applied
-- `dataOrOptions` **[String|Object][11]** Data for write actions or options for get action
-- `options` **[Object][12]** Options
-  - `options.withMeta` **[boolean][13]** Whether or not to include `createdAt` and `createdBy`
-  - `options.merge` **[boolean][13]** Merge data during set
-  - `options.batchSize` **[number][13]** Size of batch to use while deleting
-  - `options.where` **[Array][13]** Filter documents by the specified field and the value should satisfy
+- `action` **[string][mdn-string]** The action type to call with (set, push, update, delete)
+- `actionPath` **[string][mdn-string]** Path within Firestore that action should be applied
+- `dataOrOptions` **[string][mdn-string]|[object][mdn-object]** Data for write actions or options for get action
+- `options` **[object][mdn-object]** Options
+  - `options.withMeta` **[boolean][mdn-boolean]** Whether or not to include `createdAt` and `createdBy`
+  - `options.merge` **[boolean][mdn-boolean]** Merge data during set
+  - `options.batchSize` **[number][mdn-number]** Size of batch to use while deleting
+  - `options.where` **[array][mdn-array]** Filter documents by the specified field and the value should satisfy
   * the relation constraint provided
-  - `options.orderBy` **[string|Array][13]** Order documents
-  - `options.limit` **[number][13]** Limit to n number of documents
-  - `options.limitToLast` **[number][13]** Limit to last n number of documents
-  - `options.statics` **[admin.firestore][13]** Firestore statics (i.e. `admin.firestore`). This should only be needed during testing due to @firebase/testing not containing statics
+  - `options.orderBy` **[string][mdn-string]|[array][mdn-array]** Order documents
+  - `options.limit` **[number][mdn-number]** Limit to n number of documents
+  - `options.limitToLast` **[number][mdn-number]** Limit to last n number of documents
+  - `options.statics` **admin.firestore** Firestore statics (i.e. `admin.firestore`). This should only be needed during testing due to @firebase/testing not containing statics
 
 ##### Examples
 
@@ -405,6 +515,56 @@ describe('Test firestore', () => {
     });
     cy.log('Ended test');
   });
+});
+```
+
+#### cy.[authFunction]
+
+Use any of the [firebase admin auth methods](https://firebase.google.com/docs/reference/admin/node/firebase-admin.auth.baseauth#methods):
+
+- `authCreateAuthUser`
+- `authImportAuthUsers`
+- `authListAuthUsers`
+- `authGetAuthUser`
+- `authGetAuthUserByEmail`
+- `authGetAuthUserByPhoneNumber`
+- `authGetAuthUserByProviderUid`
+- `authGetAuthUsers`
+- `authUpdateAuthUser`
+- `authSetAuthUserCustomClaims`
+- `authDeleteAuthUser`
+- `authDeleteAuthUsers`
+- `authCreateCustomToken`
+- `authCreateSessionCookie`
+- `authVerifyIdToken`
+- `authRevokeRefreshTokens`
+- `authGenerateEmailVerificationLink`
+- `authGeneratePasswordResetLink`
+- `authGenerateSignInWithEmailLink`
+- `authGenerateVerifyAndChangeEmailLink`
+- `authGreateProviderConfig`
+- `authGetProviderConfig`
+- `authListProviderConfigs`
+- `authUpdateProviderCondig`
+- `authDeleteProviderConfig`
+
+##### Parameters
+
+The parameters (and return type) depend on the function used. They are the same as for the firebase api function it refers to, with addition of an optional `tenantId` parameter as last parameter:
+
+- `tenantId` **[string][mdn-string]** Optional ID of tenant used for multi-tenancy. Can also be set with environment variable TEST_TENANT_ID
+
+##### Examples
+
+```javascript
+const uid = '123SomeUid';
+const email = 'some@user.com';
+cy.authCreateUser({ uid });
+cy.authUpdateUser(uid, { displayName: 'Test User', email });
+cy.authSetCustomUserClaims(uid, { role: 'admin' });
+cy.authGetUserByEmail(email).then((user) => {
+  console.log(user?.displayName); // Test User
+  console.log(user?.customClaims?.['role']); // admin
 });
 ```
 
@@ -813,20 +973,38 @@ If you experience this with an SDK version newer than v7 please create a new iss
 - Drop support for service account file in favor of application default credentails env variable (path to file set in `GOOGLE_APPLICATION_CREDENTIALS`)
 - Support for Auth emulators (this will become the suggested method instead of needing a service account)
 
-[1]: #cylogin
-[2]: #examples
-[3]: #currentuser
-[4]: #cylogout
-[5]: #examples-1
-[6]: #cycallrtdb
-[7]: #parameters
-[8]: #examples-2
-[9]: #cycallfirestore
-[10]: #parameters-1
-[11]: #examples-3
-[12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
-[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
-[14]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[createUserWClaims]: #cycreateuserwithclaims
+[createUserWClaims-params]: #parameters
+[createUserWClaims-ex]: #examples
+[login]: #cylogin
+[login-params]: #parameters-1
+[login-ex]: #examples-1
+[loginEmail]: #cyloginwithemailandpassword
+[loginEmail-params]: #parameters-2
+[loginEmail-ex]: #examples-2
+[currentUser]: #currentuser
+[logout]: #cylogout
+[logout-params]: #parameters-3
+[logout-ex]: #examples-3
+[delAllUsers]: #cydeleteallauthusers
+[delAllUsers-params]: #examples-4
+[delAllUsers-ex]: #examples-4
+[callRtdb]: #cycallrtdb
+[callRtdb-params]: #parameters-5
+[callRtdb-ex]: #examples-5
+[callFirestore]: #cycallfirestore
+[callFirestore-params]: #parameters-6
+[callFirestore-ex]: #examples-6
+[authFunctions]: #cyauthfunction
+[authFunctions-params]: #parameters-7
+[authFunctions-ex]: #examples-7
+[mdn-string]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[mdn-number]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[mdn-boolean]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[mdn-object]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[mdn-array]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[mdn-null]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null
+[firebase-createrequest]: https://firebase.google.com/docs/reference/admin/node/firebase-admin.auth.createrequest.md#createrequest_interface
 [fireadmin-url]: https://fireadmin.io
 [fireadmin-source]: https://github.com/prescottprue/fireadmin
 [npm-image]: https://img.shields.io/npm/v/cypress-firebase.svg?style=flat-square

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -1,5 +1,6 @@
 import type { auth, firestore } from 'firebase-admin';
-import { typedTask, type createAuthUser, TaskNameToParams } from './tasks';
+import type { authCreateUser } from './tasks';
+import { typedTask, TaskNameToParams } from './tasks';
 
 /**
  * Params for attachCustomCommand function for
@@ -268,14 +269,13 @@ declare global {
       /**
        * Create a Firebase Auth user
        * @param properties - The properties to set on the new user record to be created
-       * @param customClaims - Custom claims to attach to the new user
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.createAuthUser
-       * @see https://github.com/prescottprue/cypress-firebase#cycreateauthuser
-       * cy.createAuthUser()
+       * @name cy.authCreateUser
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthcreateuser
+       * cy.authCreateUser()
        */
-      createAuthUser: (
+      authCreateUser: (
         properties: auth.CreateRequest,
         customClaims?: object | null,
         tenantId?: string,
@@ -287,13 +287,13 @@ declare global {
        * @param importOptions - Optional options for the user import
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.importAuthUsers
-       * @see https://github.com/prescottprue/cypress-firebase#cyimportauthusers
+       * @name cy.authImportUsers
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthimportusers
        * @example
-       * cy.importAuthUsers()
+       * cy.authImportUsers()
        */
-      importAuthUsers: (
-        ...args: TaskNameToParams<'importAuthUsers'>
+      authImportUsers: (
+        ...args: TaskNameToParams<'authImportUsers'>
       ) => Chainable<auth.UserImportResult>;
 
       /**
@@ -302,13 +302,13 @@ declare global {
        * @param pageToken - The next page token
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.listAuthUsers
-       * @see https://github.com/prescottprue/cypress-firebase#cylistauthusers
+       * @name cy.authListUsers
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthlistusers
        * @example
-       * cy.listAuthUsers()
+       * cy.authListUsers()
        */
-      listAuthUsers: (
-        ...args: TaskNameToParams<'listAuthUsers'>
+      authListUsers: (
+        ...args: TaskNameToParams<'authListUsers'>
       ) => Cypress.Chainable<auth.ListUsersResult>;
 
       /**
@@ -332,10 +332,11 @@ declare global {
        * email and password or the TEST_EMAIL and TEST_PASSWORD environment variables.
        * Authentication happens with serviceAccount.json or SERVICE_ACCOUNT env var.
        * @see https://github.com/prescottprue/cypress-firebase#cyloginwithemailandpassword
-       * @param email - email of user to login as
-       * @param password - password of user to login as
+       * @param email - Email of user to login as
+       * @param password - Password of user to login as
        * @param customClaims - Custom claims to attach to the custom token
-       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also be set with environment variable TEST_TENANT_ID
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
        * @example <caption>Env Based Login (TEST_EMAIL, TEST_PASSWORD)</caption>
        * cy.loginWithEmailAndPassword()
        * @example <caption>Passed email and password</caption>
@@ -361,39 +362,37 @@ declare global {
        * @param uid - UID of user to get
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.getAuthUser
-       * @see https://github.com/prescottprue/cypress-firebase#cygetauthuser
        * @example
-       * cy.getAuthUser('1234')
+       * cy.authGetUser('1234')
        */
-      getAuthUser: (
-        ...args: TaskNameToParams<'getAuthUser'>
+      authGetUser: (
+        ...args: TaskNameToParams<'authGetUser'>
       ) => Chainable<auth.UserRecord | null>;
       /**
        * Get Firebase auth user by email
        * @param email - Email of user to get
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.getAuthUserByEmail
-       * @see https://github.com/prescottprue/cypress-firebase#cygetauthuserbyemail
+       * @name cy.authGetUserByEmail
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthgetuserbyemail
        * @example
-       * cy.getAuthUserByEmail('foobar@mail.com')
+       * cy.authGetUserByEmail('foobar@mail.com')
        */
-      getAuthUserByEmail: (
-        ...args: TaskNameToParams<'getAuthUserByEmail'>
+      authGetUserByEmail: (
+        ...args: TaskNameToParams<'authGetUserByEmail'>
       ) => Chainable<auth.UserRecord | null>;
       /**
        * Get Firebase auth user by phone number
        * @param phoneNumber - Phone number of user to get
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.getAuthUserByPhoneNumber
-       * @see https://github.com/prescottprue/cypress-firebase#cygetauthuserbyphonenumber
+       * @name cy.authGetUserByPhoneNumber
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthgetuserbyphonenumber
        * @example
-       * cy.getAuthUserByPhoneNumber('1234567890')
+       * cy.authGetUserByPhoneNumber('1234567890')
        */
-      getAuthUserByPhoneNumber: (
-        ...args: TaskNameToParams<'getAuthUserByPhoneNumber'>
+      authGetUserByPhoneNumber: (
+        ...args: TaskNameToParams<'authGetUserByPhoneNumber'>
       ) => Chainable<auth.UserRecord | null>;
       /**
        * Get Firebase auth user by providerID and UID
@@ -401,13 +400,13 @@ declare global {
        * @param uid - UID of user to get
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.getAuthUserByProviderUid
-       * @see https://github.com/prescottprue/cypress-firebase#cygetauthuserbyprovideruid
+       * @name cy.authGetUserByProviderUid
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthgetuserbyprovideruid
        * @example
-       * cy.getAuthUserByProviderUid(providerId, uid)
+       * cy.authGetUserByProviderUid(providerId, uid)
        */
-      getAuthUserByProviderUid: (
-        ...args: TaskNameToParams<'getAuthUserByProviderUid'>
+      authGetUserByProviderUid: (
+        ...args: TaskNameToParams<'authGetUserByProviderUid'>
       ) => Chainable<auth.UserRecord | null>;
 
       /**
@@ -416,12 +415,12 @@ declare global {
        * @param identifiers - The identifiers used to indicate which user records should be returned.
        * @param tenantId - Optional ID of tenant used for multi-tenancy
        * @returns Promise which resolves with a GetUsersResult object
-       * @see https://github.com/prescottprue/cypress-firebase#cygetauthusers
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthgetusers
        * @example
-       * cy.getAuthUsers([{email: 'foobar@mail.com'}, {uid: "1234"}])
+       * cy.authGetUsers([{email: 'foobar@mail.com'}, {uid: "1234"}])
        */
-      getAuthUsers: (
-        ...args: TaskNameToParams<'getAuthUsers'>
+      authGetUsers: (
+        ...args: TaskNameToParams<'authGetUsers'>
       ) => Chainable<auth.GetUsersResult>;
 
       /**
@@ -430,13 +429,13 @@ declare global {
        * @param properties - The properties to update on the user
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.updateAuthUser
-       * @see https://github.com/prescottprue/cypress-firebase#cyupdateauthuser
+       * @name cy.authUpdateUser
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthupdateuser
        * @example
-       * cy.updateAuthUser(uid, {displayName: "New Name"})
+       * cy.authUpdateUser(uid, {displayName: "New Name"})
        */
-      updateAuthUser: (
-        ...args: TaskNameToParams<'updateAuthUser'>
+      authUpdateUser: (
+        ...args: TaskNameToParams<'authUpdateUser'>
       ) => Chainable<auth.UserRecord>;
       /**
        * Set custom claims of an existing Firebase Auth user
@@ -444,13 +443,13 @@ declare global {
        * @param customClaims - The custom claims to set, null deletes the custom claims
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.setAuthUserClaims
-       * @see https://github.com/prescottprue/cypress-firebase#cysetauthuserclaims
+       * @name cy.authSetCustomUserClaims
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthsetcustomuserclaims
        * @example
-       * cy.setUserClaims(uid, {some: 'claim'})
+       * cy.authSetCustomUserClaims(uid, {some: 'claim'})
        */
-      setAuthUserClaims: (
-        ...args: TaskNameToParams<'setAuthUserCustomClaims'>
+      authSetCustomUserClaims: (
+        ...args: TaskNameToParams<'authSetCustomUserClaims'>
       ) => Chainable<null>;
 
       /**
@@ -459,13 +458,13 @@ declare global {
        * @param uid = UID of user to delete
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.deleteAuthUser
-       * @see https://github.com/prescottprue/cypress-firebase#cydeleteauthuser
+       * @name cy.authDeleteUser
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthdeleteuser
        * @example
-       * cy.deleteAuthUser(uid)
+       * cy.authDeleteUser(uid)
        */
-      deleteAuthUser: (
-        ...args: TaskNameToParams<'deleteAuthUser'>
+      authDeleteUser: (
+        ...args: TaskNameToParams<'authDeleteUser'>
       ) => Chainable<null>;
       /**
        * Delete a user from Firebase Auth with either a passed uid or the TEST_UID
@@ -473,13 +472,13 @@ declare global {
        * @param uid = UID of user to delete
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.deleteAllAuthUsers
-       * @see https://github.com/prescottprue/cypress-firebase#cydeleteauthusers
+       * @name cy.authDeleteUsers
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthdeleteusers
        * @example
-       * cy.deleteAuthUsers([uid1, uid2])
+       * cy.authDeleteUsers([uid1, uid2])
        */
-      deleteAuthUsers: (
-        ...args: TaskNameToParams<'deleteAuthUsers'>
+      authDeleteUsers: (
+        ...args: TaskNameToParams<'authDeleteUsers'>
       ) => Chainable<auth.DeleteUsersResult>;
       /**
        * Delete all users from Firebase Auth
@@ -500,13 +499,13 @@ declare global {
        * @param customClaims - Custom claims to attach to the custom token
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.createCustomToken
-       * @see https://github.com/prescottprue/cypress-firebase#cycreatecustomtoken
+       * @name cy.authCreateCustomToken
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthcreatecustomtoken
        * @example
-       * cy.createCustomToken(uid)
+       * cy.authCreateCustomToken(uid)
        */
-      createCustomToken: (
-        ...args: TaskNameToParams<'createCustomToken'>
+      authCreateCustomToken: (
+        ...args: TaskNameToParams<'authCreateCustomToken'>
       ) => Chainable<string>;
       /**
        * Create a session cookie for a user
@@ -514,13 +513,13 @@ declare global {
        * @param sessionCookieOptions - Options for the session cookie
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.createSessionCookie
-       * @see https://github.com/prescottprue/cypress-firebase#cycreatesessioncookie
+       * @name cy.authCreateSessionCookie
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthcreatesessioncookie
        * @example
-       * cy.createSessionCookie(idToken)
+       * cy.authCreateSessionCookie(idToken)
        */
-      createSessionCookie: (
-        ...args: TaskNameToParams<'createSessionCookie'>
+      authCreateSessionCookie: (
+        ...args: TaskNameToParams<'authCreateSessionCookie'>
       ) => Chainable<string>;
       /**
        * Verify an ID token
@@ -528,26 +527,26 @@ declare global {
        * @param checkRevoked - Whether to check if the token has been revoked
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.verifyIdToken
-       * @see https://github.com/prescottprue/cypress-firebase#cyverifyidtoken
+       * @name cy.authVerifyIdToken
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthverifyidtoken
        * @example
-       * cy.verifyIdToken(idToken)
+       * cy.authVerifyIdToken(idToken)
        */
-      verifyIdToken: (
-        ...args: TaskNameToParams<'verifyIdToken'>
+      authVerifyIdToken: (
+        ...args: TaskNameToParams<'authVerifyIdToken'>
       ) => Chainable<auth.DecodedIdToken>;
       /**
        * Revoke all refresh tokens for a user
        * @param uid - UID of user to revoke refresh tokens for
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.revokeRefreshTokens
-       * @see https://github.com/prescottprue/cypress-firebase#cyrevokerefreshtokens
+       * @name cy.authRevokeRefreshTokens
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthrevokerefreshtokens
        * @example
-       * cy.revokeRefreshTokens(uid)
+       * cy.authRevokeRefreshTokens(uid)
        */
-      revokeRefreshTokens: (
-        ...args: TaskNameToParams<'revokeRefreshTokens'>
+      authRevokeRefreshTokens: (
+        ...args: TaskNameToParams<'authRevokeRefreshTokens'>
       ) => Chainable<void>;
       /**
        * Generate an email verification link
@@ -555,13 +554,13 @@ declare global {
        * @param actionCodeSettings - Action code settings for the email
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.generateEmailVerificationLink
-       * @see https://github.com/prescottprue/cypress-firebase#cygenerateemailverificationlink
+       * @name cy.authGenerateEmailVerificationLink
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthgenerateemailverificationlink
        * @example
-       * cy.generateEmailVerificationLink(email)
+       * cy.authGenerateEmailVerificationLink(email)
        */
-      generateEmailVerificationLink: (
-        ...args: TaskNameToParams<'generateEmailVerificationLink'>
+      authGenerateEmailVerificationLink: (
+        ...args: TaskNameToParams<'authGenerateEmailVerificationLink'>
       ) => Chainable<string>;
       /**
        * Generate a password reset link
@@ -569,13 +568,13 @@ declare global {
        * @param actionCodeSettings - Action code settings for the email
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.generatePasswordResetLink
-       * @see https://github.com/prescottprue/cypress-firebase#cygeneratepasswordresetlink
+       * @name cy.authGeneratePasswordResetLink
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthgeneratepasswordresetlink
        * @example
-       * cy.generatePasswordResetLink(email)
+       * cy.authGeneratePasswordResetLink(email)
        */
-      generatePasswordResetLink: (
-        ...args: TaskNameToParams<'generatePasswordResetLink'>
+      authGeneratePasswordResetLink: (
+        ...args: TaskNameToParams<'authGeneratePasswordResetLink'>
       ) => Chainable<string>;
       /**
        * Generate a sign in with email link
@@ -583,13 +582,13 @@ declare global {
        * @param actionCodeSettings - Action code settings for the email
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.generateSignInWithEmailLink
-       * @see https://github.com/prescottprue/cypress-firebase#cygeneratesigninwithemaillink
+       * @name cy.authGenerateSignInWithEmailLink
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthgeneratesigninwithemaillink
        * @example
-       * cy.generateSignInWithEmailLink(email, actionCodeSettings)
+       * cy.authGenerateSignInWithEmailLink(email, actionCodeSettings)
        */
-      generateSignInWithEmailLink: (
-        ...args: TaskNameToParams<'generateSignInWithEmailLink'>
+      authGenerateSignInWithEmailLink: (
+        ...args: TaskNameToParams<'authGenerateSignInWithEmailLink'>
       ) => Chainable<string>;
 
       /**
@@ -599,13 +598,13 @@ declare global {
        * @param actionCodeSettings - Action code settings for the email
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.generateVerifyAndChangeEmailLink
-       * @see https://github.com/prescottprue/cypress-firebase#cygenerateverifyandchangeemaillink
+       * @name cy.authGenerateVerifyAndChangeEmailLink
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthgenerateverifyandchangeemaillink
        * @example
-       * cy.generateVerifyAndChangeEmailLink(oldEmail, newEmail)
+       * cy.authGenerateVerifyAndChangeEmailLink(oldEmail, newEmail)
        */
-      generateVerifyAndChangeEmailLink: (
-        ...args: TaskNameToParams<'generateVerifyAndChangeEmailLink'>
+      authGenerateVerifyAndChangeEmailLink: (
+        ...args: TaskNameToParams<'authGenerateVerifyAndChangeEmailLink'>
       ) => Chainable<string>;
 
       /**
@@ -613,39 +612,39 @@ declare global {
        * @param providerConfig - The provider config to create
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.createProviderConfig
-       * @see https://github.com/prescottprue/cypress-firebase#cycreateproviderconfig
+       * @name cy.authCreateProviderConfig
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthcreateproviderconfig
        * @example
-       * cy.createProviderConfig(providerConfig)
+       * cy.authCreateProviderConfig(providerConfig)
        */
-      createProviderConfig: (
-        ...args: TaskNameToParams<'createProviderConfig'>
+      authCreateProviderConfig: (
+        ...args: TaskNameToParams<'authCreateProviderConfig'>
       ) => Chainable<auth.AuthProviderConfig>;
       /**
        * Get a provider config
        * @param providerId - The provider ID to get the config for
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.getProviderConfig
-       * @see https://github.com/prescottprue/cypress-firebase#cygetproviderconfig
+       * @name cy.authGetProviderConfig
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthgetproviderconfig
        * @example
-       * cy.getProviderConfig(providerId)
+       * cy.authGetProviderConfig(providerId)
        */
-      getProviderConfig: (
-        ...args: TaskNameToParams<'getProviderConfig'>
+      authGetProviderConfig: (
+        ...args: TaskNameToParams<'authGetProviderConfig'>
       ) => Chainable<auth.AuthProviderConfig>;
       /**
        * List provider configs
        * @param providerFilter - The provider ID to filter by, or null to list all
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.listProviderConfigs
-       * @see https://github.com/prescottprue/cypress-firebase#cylistproviderconfigs
+       * @name cy.authListProviderConfigs
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthlistproviderconfigs
        * @example
-       * cy.listProviderConfigs(providerFilter)
+       * cy.authListProviderConfigs(providerFilter)
        */
-      listProviderConfigs: (
-        ...args: TaskNameToParams<'listProviderConfigs'>
+      authListProviderConfigs: (
+        ...args: TaskNameToParams<'authListProviderConfigs'>
       ) => Chainable<auth.ListProviderConfigResults>;
       /**
        * Update a provider config
@@ -653,26 +652,26 @@ declare global {
        * @param providerConfig - The provider config to update to
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.updateProviderConfig
-       * @see https://github.com/prescottprue/cypress-firebase#cyupdateproviderconfig
+       * @name cy.authUpdateProviderConfig
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthupdateproviderconfig
        * @example
-       * cy.updateProviderConfig(providerId, providerConfig)
+       * cy.authUpdateProviderConfig(providerId, providerConfig)
        */
-      updateProviderConfig: (
-        ...args: TaskNameToParams<'updateProviderConfig'>
+      authUpdateProviderConfig: (
+        ...args: TaskNameToParams<'authUpdateProviderConfig'>
       ) => Chainable<auth.AuthProviderConfig>;
       /**
        * Delete a provider config
        * @param providerId - The provider ID to delete the config for
        * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
        * be set with environment variable TEST_TENANT_ID
-       * @name cy.deleteProviderConfig
-       * @see https://github.com/prescottprue/cypress-firebase#cydeleteproviderconfig
+       * @name cy.authDeleteProviderConfig
+       * @see https://github.com/prescottprue/cypress-firebase#cyauthdeleteproviderconfig
        * @example
-       * cy.deleteProviderConfig(providerId)
+       * cy.authDeleteProviderConfig(providerId)
        */
-      deleteProviderConfig: (
-        ...args: TaskNameToParams<'deleteProviderConfig'>
+      authDeleteProviderConfig: (
+        ...args: TaskNameToParams<'authDeleteProviderConfig'>
       ) => Chainable<null>;
     }
   }
@@ -752,18 +751,18 @@ function loginWithEmailAndPassword(
  * @param pageToken - Page token used for recursion
  * @returns Promise which resolves when all users have been deleted
  */
-function deleteAllAuthUsers(
+function authDeleteAllUsers(
   cy: AttachCustomCommandParams['cy'],
   tenantId?: string | undefined,
   pageToken?: string,
 ): Promise<void> {
   return new Promise<void>((resolve, reject): any => {
-    typedTask(cy, 'listAuthUsers', { tenantId, pageToken }).then(
+    typedTask(cy, 'authListUsers', { tenantId, pageToken }).then(
       ({ users, pageToken: nextPageToken }) => {
         if (users.length === 0) resolve();
         else {
           const uids = users.map((user) => user.uid);
-          typedTask(cy, 'deleteAuthUsers', { uids, tenantId }).then(
+          typedTask(cy, 'authDeleteUsers', { uids, tenantId }).then(
             ({ successCount, failureCount }) => {
               if (failureCount > successCount || successCount === 0)
                 reject(
@@ -771,7 +770,7 @@ function deleteAllAuthUsers(
                     `Too many deletes failed. ${successCount} users were deleted, ${failureCount} failed.`,
                   ),
                 );
-              deleteAllAuthUsers(cy, tenantId, nextPageToken).then(resolve);
+              authDeleteAllUsers(cy, tenantId, nextPageToken).then(resolve);
             },
           );
         }
@@ -783,35 +782,35 @@ function deleteAllAuthUsers(
 type CommandNames =
   | 'callRtdb'
   | 'callFirestore'
-  | 'createAuthUser'
-  | 'importAuthUsers'
-  | 'listAuthUsers'
+  | 'authCreateUser'
+  | 'authImportUsers'
+  | 'authListUsers'
   | 'login'
   | 'loginWithEmailAndPassword'
   | 'logout'
-  | 'getAuthUser'
-  | 'getAuthUserByEmail'
-  | 'getAuthUserByPhoneNumber'
-  | 'getAuthUserByProviderUid'
-  | 'getAuthUsers'
-  | 'updateAuthUser'
-  | 'setAuthUserClaims'
-  | 'deleteAuthUser'
-  | 'deleteAuthUsers'
+  | 'authGetUser'
+  | 'authGetUserByEmail'
+  | 'authGetUserByPhoneNumber'
+  | 'authGetUserByProviderUid'
+  | 'authGetUsers'
+  | 'authUpdateUser'
+  | 'authSetCustomUserClaims'
+  | 'authDeleteUser'
+  | 'authDeleteUsers'
   | 'deleteAllAuthUsers'
-  | 'createCustomToken'
-  | 'createSessionCookie'
-  | 'verifyIdToken'
-  | 'revokeRefreshTokens'
-  | 'generateEmailVerificationLink'
-  | 'generatePasswordResetLink'
-  | 'generateSignInWithEmailLink'
-  | 'generateVerifyAndChangeEmailLink'
-  | 'createProviderConfig'
-  | 'getProviderConfig'
-  | 'listProviderConfigs'
-  | 'updateProviderConfig'
-  | 'deleteProviderConfig';
+  | 'authCreateCustomToken'
+  | 'authCreateSessionCookie'
+  | 'authVerifyIdToken'
+  | 'authRevokeRefreshTokens'
+  | 'authGenerateEmailVerificationLink'
+  | 'authGeneratePasswordResetLink'
+  | 'authGenerateSignInWithEmailLink'
+  | 'authGenerateVerifyAndChangeEmailLink'
+  | 'authCreateProviderConfig'
+  | 'authGetProviderConfig'
+  | 'authListProviderConfigs'
+  | 'authUpdateProviderConfig'
+  | 'authDeleteProviderConfig';
 
 type CommandNamespacesConfig = {
   [N in CommandNames]?: string | boolean;
@@ -932,14 +931,14 @@ export default function attachCustomCommands(
   );
 
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.createAuthUser) ||
-      'createAuthUser',
+    (options && options.commandNames && options.commandNames.authCreateUser) ||
+      'authCreateUser',
     (
       properties: auth.CreateRequest,
       customClaims?: object | null,
       tenantId: string = Cypress.env('TEST_TENANT_ID'),
     ) =>
-      typedTask(cy, 'createAuthUser', { properties, tenantId }).then((user) => {
+      typedTask(cy, 'authCreateUser', { properties, tenantId }).then((user) => {
         if (user === 'auth/email-already-exists') {
           if (!properties.email) {
             throw new Error(
@@ -947,7 +946,7 @@ export default function attachCustomCommands(
             );
           }
           cy.log('Auth user with given email already exists.');
-          return typedTask(cy, 'getAuthUserByEmail', {
+          return typedTask(cy, 'authGetUserByEmail', {
             email: properties.email,
             tenantId,
           }).then((user) =>
@@ -963,7 +962,7 @@ export default function attachCustomCommands(
             );
           }
           cy.log('Auth user with given phone number already exists.');
-          return typedTask(cy, 'getAuthUserByPhoneNumber', {
+          return typedTask(cy, 'authGetUserByPhoneNumber', {
             phoneNumber: properties.phoneNumber,
             tenantId,
           }).then((user) =>
@@ -973,7 +972,7 @@ export default function attachCustomCommands(
           );
         }
         if (customClaims !== undefined && user) {
-          return typedTask(cy, 'setAuthUserCustomClaims', {
+          return typedTask(cy, 'authSetCustomUserClaims', {
             uid: user.uid,
             customClaims,
             tenantId,
@@ -984,10 +983,10 @@ export default function attachCustomCommands(
   );
 
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.importAuthUsers) ||
-      'importAuthUsers',
-    (...args: TaskNameToParams<'importAuthUsers'>) =>
-      typedTask(cy, 'importAuthUsers', {
+    (options && options.commandNames && options.commandNames.authImportUsers) ||
+      'authImportUsers',
+    (...args: TaskNameToParams<'authImportUsers'>) =>
+      typedTask(cy, 'authImportUsers', {
         usersImport: args[0],
         importOptions: args[1],
         tenantId: args[2] || Cypress.env('TEST_TENANT_ID'),
@@ -995,10 +994,10 @@ export default function attachCustomCommands(
   );
 
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.listAuthUsers) ||
-      'listAuthUsers',
-    (...args: TaskNameToParams<'listAuthUsers'>) =>
-      typedTask(cy, 'listAuthUsers', {
+    (options && options.commandNames && options.commandNames.authListUsers) ||
+      'authListUsers',
+    (...args: TaskNameToParams<'authListUsers'>) =>
+      typedTask(cy, 'authListUsers', {
         maxResults: args[0],
         pageToken: args[1],
         tenantId: args[2] || Cypress.env('TEST_TENANT_ID'),
@@ -1028,8 +1027,8 @@ export default function attachCustomCommands(
 
       cy.log('Creating custom token for login...');
 
-      // Generate a custom token using createCustomToken task (if tasks are enabled) then login
-      return typedTask(cy, 'createCustomToken', {
+      // Generate a custom token using authCreateCustomToken task (if tasks are enabled) then login
+      return typedTask(cy, 'authCreateCustomToken', {
         uid: userUid,
         customClaims,
         tenantId,
@@ -1046,7 +1045,7 @@ export default function attachCustomCommands(
       email?: string,
       password?: string,
       extraInfo?: Omit<
-        Parameters<typeof createAuthUser>[1],
+        Parameters<typeof authCreateUser>[1],
         'email' | 'password'
       >,
       tenantId: string | undefined = Cypress.env('TEST_TENANT_ID'),
@@ -1072,13 +1071,13 @@ export default function attachCustomCommands(
         cy.log('Authed user already exists, login complete.');
         return undefined;
       }
-      return typedTask(cy, 'getAuthUserByEmail', {
+      return typedTask(cy, 'authGetUserByEmail', {
         email: userEmail,
         tenantId,
       }).then((user) => {
         if (user)
           return loginWithEmailAndPassword(auth, userEmail, userPassword);
-        typedTask(cy, 'createAuthUser', {
+        typedTask(cy, 'authCreateUser', {
           properties: {
             uid: userUid,
             email: userEmail,
@@ -1088,7 +1087,7 @@ export default function attachCustomCommands(
           tenantId,
         });
         return cy
-          .task('createAuthUser', {
+          .task('authCreateUser', {
             properties: {
               email: userEmail,
               password: userPassword,
@@ -1124,8 +1123,8 @@ export default function attachCustomCommands(
   );
 
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.getAuthUser) ||
-      'getAuthUser',
+    (options && options.commandNames && options.commandNames.authGetUser) ||
+      'authGetUser',
     (uid?: string, tenantId?: string) => {
       const userUid = uid || Cypress.env('TEST_UID');
       // Handle UID which is passed in
@@ -1134,7 +1133,7 @@ export default function attachCustomCommands(
           'uid must be passed or TEST_UID set within environment to login',
         );
       }
-      return typedTask(cy, 'getAuthUser', {
+      return typedTask(cy, 'authGetUser', {
         uid: userUid,
         tenantId: tenantId || Cypress.env('TEST_TENANT_ID'),
       }).then((user) => {
@@ -1147,8 +1146,8 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.getAuthUserByEmail) ||
-      'getAuthUserByEmail',
+      options.commandNames.authGetUserByEmail) ||
+      'authGetUserByEmail',
     (email?: string, tenantId?: string) => {
       const userEmail = email || Cypress.env('TEST_EMAIL');
       // Handle email which is passed in
@@ -1157,7 +1156,7 @@ export default function attachCustomCommands(
           'email must be passed or TEST_EMAIL set within environment to login',
         );
       }
-      return typedTask(cy, 'getAuthUserByEmail', {
+      return typedTask(cy, 'authGetUserByEmail', {
         email: userEmail,
         tenantId: tenantId || Cypress.env('TEST_TENANT_ID'),
       }).then((user) => {
@@ -1170,10 +1169,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.getAuthUserByPhoneNumber) ||
-      'getAuthUserByPhoneNumber',
-    (...args: TaskNameToParams<'getAuthUserByPhoneNumber'>) =>
-      typedTask(cy, 'getAuthUserByPhoneNumber', {
+      options.commandNames.authGetUserByPhoneNumber) ||
+      'authGetUserByPhoneNumber',
+    (...args: TaskNameToParams<'authGetUserByPhoneNumber'>) =>
+      typedTask(cy, 'authGetUserByPhoneNumber', {
         phoneNumber: args[0],
         tenantId: args[1] || Cypress.env('TEST_TENANT_ID'),
       }).then((user) => {
@@ -1185,8 +1184,8 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.getAuthUserByProviderUid) ||
-      'getAuthUserByProviderUid',
+      options.commandNames.authGetUserByProviderUid) ||
+      'authGetUserByProviderUid',
     (providerId: string, uid?: string, tenantId?: string) => {
       const userUid = uid || Cypress.env('TEST_UID');
       // Handle UID which is passed in
@@ -1195,7 +1194,7 @@ export default function attachCustomCommands(
           'uid must be passed or TEST_UID set within environment to login',
         );
       }
-      typedTask(cy, 'getAuthUserByProviderUid', {
+      typedTask(cy, 'authGetUserByProviderUid', {
         providerId,
         uid: userUid,
         tenantId: tenantId || Cypress.env('TEST_TENANT_ID'),
@@ -1207,20 +1206,20 @@ export default function attachCustomCommands(
   );
 
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.getAuthUsers) ||
-      'getAuthUsers',
-    (...args: TaskNameToParams<'getAuthUsers'>) =>
-      typedTask(cy, 'getAuthUsers', {
+    (options && options.commandNames && options.commandNames.authGetUsers) ||
+      'authGetUsers',
+    (...args: TaskNameToParams<'authGetUsers'>) =>
+      typedTask(cy, 'authGetUsers', {
         identifiers: args[0],
         tenantId: args[1] || Cypress.env('TEST_TENANT_ID'),
       }),
   );
 
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.updateAuthUser) ||
-      'updateAuthUser',
-    (...args: TaskNameToParams<'updateAuthUser'>) =>
-      typedTask(cy, 'updateAuthUser', {
+    (options && options.commandNames && options.commandNames.authUpdateUser) ||
+      'authUpdateUser',
+    (...args: TaskNameToParams<'authUpdateUser'>) =>
+      typedTask(cy, 'authUpdateUser', {
         uid: args[0],
         properties: args[1],
         tenantId: args[2] || Cypress.env('TEST_TENANT_ID'),
@@ -1230,10 +1229,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.setAuthUserClaims) ||
-      'setAuthUserClaims',
-    (...args: TaskNameToParams<'setAuthUserCustomClaims'>) =>
-      typedTask(cy, 'setAuthUserCustomClaims', {
+      options.commandNames.authSetCustomUserClaims) ||
+      'authSetCustomUserClaims',
+    (...args: TaskNameToParams<'authSetCustomUserClaims'>) =>
+      typedTask(cy, 'authSetCustomUserClaims', {
         uid: args[0],
         customClaims: args[1],
         tenantId: args[2] || Cypress.env('TEST_TENANT_ID'),
@@ -1241,8 +1240,8 @@ export default function attachCustomCommands(
   );
 
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.deleteAuthUser) ||
-      'deleteAuthUser',
+    (options && options.commandNames && options.commandNames.authDeleteUser) ||
+      'authDeleteUser',
     (
       uid?: string,
       tenantId: string | undefined = Cypress.env('TEST_TENANT_ID'),
@@ -1255,15 +1254,15 @@ export default function attachCustomCommands(
         );
       }
 
-      return typedTask(cy, 'deleteAuthUser', { uid: userUid, tenantId });
+      return typedTask(cy, 'authDeleteUser', { uid: userUid, tenantId });
     },
   );
 
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.deleteAuthUsers) ||
-      'deleteAuthUsers',
-    (...args: TaskNameToParams<'deleteAuthUsers'>) =>
-      typedTask(cy, 'deleteAuthUsers', {
+    (options && options.commandNames && options.commandNames.authDeleteUsers) ||
+      'authDeleteUsers',
+    (...args: TaskNameToParams<'authDeleteUsers'>) =>
+      typedTask(cy, 'authDeleteUsers', {
         uids: args[0],
         tenantId: args[1] || Cypress.env('TEST_TENANT_ID'),
       }),
@@ -1275,14 +1274,14 @@ export default function attachCustomCommands(
       options.commandNames.deleteAllAuthUsers) ||
       'deleteAllAuthUsers',
     (tenantId: string | undefined = Cypress.env('TEST_TENANT_ID')) =>
-      cy.wrap(deleteAllAuthUsers(cy, tenantId)),
+      cy.wrap(authDeleteAllUsers(cy, tenantId)),
   );
 
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.createCustomToken) ||
-      'createCustomToken',
+      options.commandNames.authCreateCustomToken) ||
+      'authCreateCustomToken',
     (uid?: string, customClaims?: object, tenantId?: string) => {
       const userUid = uid || Cypress.env('TEST_UID');
       // Handle UID which is passed in
@@ -1291,7 +1290,7 @@ export default function attachCustomCommands(
           'uid must be passed or TEST_UID set within environment to login',
         );
       }
-      return typedTask(cy, 'createCustomToken', {
+      return typedTask(cy, 'authCreateCustomToken', {
         uid: userUid,
         customClaims,
         tenantId: tenantId || Cypress.env('TEST_TENANT_ID'),
@@ -1302,10 +1301,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.createSessionCookie) ||
-      'createSessionCookie',
-    (...args: TaskNameToParams<'createSessionCookie'>) =>
-      typedTask(cy, 'createSessionCookie', {
+      options.commandNames.authCreateSessionCookie) ||
+      'authCreateSessionCookie',
+    (...args: TaskNameToParams<'authCreateSessionCookie'>) =>
+      typedTask(cy, 'authCreateSessionCookie', {
         idToken: args[0],
         sessionCookieOptions: args[1],
         tenantId: args[2] || Cypress.env('TEST_TENANT_ID'),
@@ -1313,10 +1312,12 @@ export default function attachCustomCommands(
   );
 
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.verifyIdToken) ||
-      'verifyIdToken',
-    (...args: TaskNameToParams<'verifyIdToken'>) =>
-      typedTask(cy, 'verifyIdToken', {
+    (options &&
+      options.commandNames &&
+      options.commandNames.authVerifyIdToken) ||
+      'authVerifyIdToken',
+    (...args: TaskNameToParams<'authVerifyIdToken'>) =>
+      typedTask(cy, 'authVerifyIdToken', {
         idToken: args[0],
         checkRevoked: args[1],
         tenantId: args[2] || Cypress.env('TEST_TENANT_ID'),
@@ -1326,8 +1327,8 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.revokeRefreshTokens) ||
-      'revokeRefreshTokens',
+      options.commandNames.authRevokeRefreshTokens) ||
+      'authRevokeRefreshTokens',
     (uid?: string, tenantId?: string) => {
       const userUid = uid || Cypress.env('TEST_UID');
       // Handle UID which is passed in
@@ -1336,7 +1337,7 @@ export default function attachCustomCommands(
           'uid must be passed or TEST_UID set within environment to login',
         );
       }
-      return typedTask(cy, 'revokeRefreshTokens', {
+      return typedTask(cy, 'authRevokeRefreshTokens', {
         uid: userUid,
         tenantId: tenantId || Cypress.env('TEST_TENANT_ID'),
       });
@@ -1346,8 +1347,8 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.generateEmailVerificationLink) ||
-      'generateEmailVerificationLink',
+      options.commandNames.authGenerateEmailVerificationLink) ||
+      'authGenerateEmailVerificationLink',
     (
       email?: string,
       actionCodeSettings?: auth.ActionCodeSettings,
@@ -1360,7 +1361,7 @@ export default function attachCustomCommands(
           'email must be passed or TEST_EMAIL set within environment to login',
         );
       }
-      return typedTask(cy, 'generateEmailVerificationLink', {
+      return typedTask(cy, 'authGenerateEmailVerificationLink', {
         email: userEmail,
         actionCodeSettings,
         tenantId: tenantId || Cypress.env('TEST_TENANT_ID'),
@@ -1371,8 +1372,8 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.generatePasswordResetLink) ||
-      'generatePasswordResetLink',
+      options.commandNames.authGeneratePasswordResetLink) ||
+      'authGeneratePasswordResetLink',
     (
       email?: string,
       actionCodeSettings?: auth.ActionCodeSettings,
@@ -1385,7 +1386,7 @@ export default function attachCustomCommands(
           'email must be passed or TEST_EMAIL set within environment to login',
         );
       }
-      return typedTask(cy, 'generatePasswordResetLink', {
+      return typedTask(cy, 'authGeneratePasswordResetLink', {
         email: userEmail,
         actionCodeSettings,
         tenantId: tenantId || Cypress.env('TEST_TENANT_ID'),
@@ -1396,10 +1397,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.generateSignInWithEmailLink) ||
-      'generateSignInWithEmailLink',
-    (...args: TaskNameToParams<'generateSignInWithEmailLink'>) =>
-      typedTask(cy, 'generateSignInWithEmailLink', {
+      options.commandNames.authGenerateSignInWithEmailLink) ||
+      'authGenerateSignInWithEmailLink',
+    (...args: TaskNameToParams<'authGenerateSignInWithEmailLink'>) =>
+      typedTask(cy, 'authGenerateSignInWithEmailLink', {
         email: args[0],
         actionCodeSettings: args[1],
         tenantId: args[2] || Cypress.env('TEST_TENANT_ID'),
@@ -1409,10 +1410,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.generateVerifyAndChangeEmailLink) ||
-      'generateVerifyAndChangeEmailLink',
-    (...args: TaskNameToParams<'generateVerifyAndChangeEmailLink'>) =>
-      typedTask(cy, 'generateVerifyAndChangeEmailLink', {
+      options.commandNames.authGenerateVerifyAndChangeEmailLink) ||
+      'authGenerateVerifyAndChangeEmailLink',
+    (...args: TaskNameToParams<'authGenerateVerifyAndChangeEmailLink'>) =>
+      typedTask(cy, 'authGenerateVerifyAndChangeEmailLink', {
         email: args[0],
         newEmail: args[1],
         actionCodeSettings: args[2],
@@ -1423,10 +1424,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.createProviderConfig) ||
-      'createProviderConfig',
-    (...args: TaskNameToParams<'createProviderConfig'>) =>
-      typedTask(cy, 'createProviderConfig', {
+      options.commandNames.authCreateProviderConfig) ||
+      'authCreateProviderConfig',
+    (...args: TaskNameToParams<'authCreateProviderConfig'>) =>
+      typedTask(cy, 'authCreateProviderConfig', {
         providerConfig: args[0],
         tenantId: args[1] || Cypress.env('TEST_TENANT_ID'),
       }),
@@ -1435,10 +1436,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.getProviderConfig) ||
-      'getProviderConfig',
-    (...args: TaskNameToParams<'getProviderConfig'>) =>
-      typedTask(cy, 'getProviderConfig', {
+      options.commandNames.authGetProviderConfig) ||
+      'authGetProviderConfig',
+    (...args: TaskNameToParams<'authGetProviderConfig'>) =>
+      typedTask(cy, 'authGetProviderConfig', {
         providerId: args[0],
         tenantId: args[1] || Cypress.env('TEST_TENANT_ID'),
       }),
@@ -1447,10 +1448,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.listProviderConfigs) ||
-      'listProviderConfigs',
-    (...args: TaskNameToParams<'listProviderConfigs'>) =>
-      typedTask(cy, 'listProviderConfigs', {
+      options.commandNames.authListProviderConfigs) ||
+      'authListProviderConfigs',
+    (...args: TaskNameToParams<'authListProviderConfigs'>) =>
+      typedTask(cy, 'authListProviderConfigs', {
         providerFilter: args[0],
         tenantId: args[1] || Cypress.env('TEST_TENANT_ID'),
       }),
@@ -1459,10 +1460,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.updateProviderConfig) ||
-      'updateProviderConfig',
-    (...args: TaskNameToParams<'updateProviderConfig'>) =>
-      typedTask(cy, 'updateProviderConfig', {
+      options.commandNames.authUpdateProviderConfig) ||
+      'authUpdateProviderConfig',
+    (...args: TaskNameToParams<'authUpdateProviderConfig'>) =>
+      typedTask(cy, 'authUpdateProviderConfig', {
         providerId: args[0],
         providerConfig: args[1],
         tenantId: args[2] || Cypress.env('TEST_TENANT_ID'),
@@ -1472,10 +1473,10 @@ export default function attachCustomCommands(
   Cypress.Commands.add(
     (options &&
       options.commandNames &&
-      options.commandNames.deleteProviderConfig) ||
-      'deleteProviderConfig',
-    (...args: TaskNameToParams<'deleteProviderConfig'>) =>
-      typedTask(cy, 'deleteProviderConfig', {
+      options.commandNames.authDeleteProviderConfig) ||
+      'authDeleteProviderConfig',
+    (...args: TaskNameToParams<'authDeleteProviderConfig'>) =>
+      typedTask(cy, 'authDeleteProviderConfig', {
         providerId: args[0],
         tenantId: args[1] || Cypress.env('TEST_TENANT_ID'),
       }),

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -928,6 +928,34 @@ export default function attachCustomCommands(
       tenantId: string = Cypress.env('TEST_TENANT_ID'),
     ): any =>
       typedTask(cy, 'createAuthUser', { properties, tenantId }).then((user) => {
+        if (user === 'auth/email-already-exists') {
+          if (!properties.email) {
+            throw new Error(
+              'User with email already exists yet no email was given',
+            );
+          }
+          cy.log('Auth user with given email already exists.');
+          return typedTask(cy, 'getAuthUserByEmail', {
+            email: properties.email,
+            tenantId,
+          }).then((user) =>
+            user === 'auth/user-not-found' ? null : user?.uid,
+          );
+        }
+        if (user === 'auth/phone-number-already-exists') {
+          if (!properties.phoneNumber) {
+            throw new Error(
+              'User with phone number already exists yet no phone number was given',
+            );
+          }
+          cy.log('Auth user with given phone number already exists.');
+          return typedTask(cy, 'getAuthUserByPhoneNumber', {
+            phoneNumber: properties.phoneNumber,
+            tenantId,
+          }).then((user) =>
+            user === 'auth/user-not-found' ? null : user?.uid,
+          );
+        }
         if (customClaims !== undefined && user) {
           return typedTask(cy, 'setAuthUserCustomClaims', {
             uid: user.uid,
@@ -1087,6 +1115,9 @@ export default function attachCustomCommands(
       return typedTask(cy, 'getAuthUser', {
         uid: userUid,
         tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      }).then((user) => {
+        if (user === 'auth/user-not-found') return null;
+        return user;
       });
     },
   );
@@ -1104,6 +1135,9 @@ export default function attachCustomCommands(
       return typedTask(cy, 'getAuthUserByEmail', {
         email: userEmail,
         tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      }).then((user) => {
+        if (user === 'auth/user-not-found') return null;
+        return user;
       });
     },
   );
@@ -1115,6 +1149,9 @@ export default function attachCustomCommands(
       typedTask(cy, 'getAuthUserByPhoneNumber', {
         phoneNumber: args[0],
         tenantId: args[1] ?? Cypress.env('TEST_TENANT_ID'),
+      }).then((user) => {
+        if (user === 'auth/user-not-found') return null;
+        return user;
       }),
   );
 
@@ -1133,6 +1170,9 @@ export default function attachCustomCommands(
         providerId,
         uid: userUid,
         tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      }).then((user) => {
+        if (user === 'auth/user-not-found') return null;
+        return user;
       });
     },
   );

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -793,6 +793,7 @@ type CommandNames =
   | 'getAuthUserByEmail'
   | 'getAuthUserByPhoneNumber'
   | 'getAuthUserByProviderUid'
+  | 'getAuthUsers'
   | 'updateAuthUser'
   | 'setAuthUserClaims'
   | 'deleteAuthUser'
@@ -1183,6 +1184,15 @@ export default function attachCustomCommands(
         return user;
       });
     },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.getAuthUsers ?? 'getAuthUsers',
+    (...args: TaskNameToParams<'getAuthUsers'>) =>
+      typedTask(cy, 'getAuthUsers', {
+        identifiers: args[0],
+        tenantId: args[1] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
   );
 
   Cypress.Commands.add(

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -279,7 +279,7 @@ declare global {
         properties: auth.CreateRequest,
         customClaims?: object | null,
         tenantId?: string,
-      ) => Chainable;
+      ) => Chainable<string | undefined>;
 
       /**
        * Import list of Firebase Auth users
@@ -294,7 +294,7 @@ declare global {
        */
       importAuthUsers: (
         ...args: TaskNameToParams<'importAuthUsers'>
-      ) => Chainable;
+      ) => Chainable<auth.UserImportResult>;
 
       /**
        * List Firebase Auth users
@@ -307,7 +307,9 @@ declare global {
        * @example
        * cy.listAuthUsers()
        */
-      listAuthUsers: (...args: TaskNameToParams<'listAuthUsers'>) => Chainable;
+      listAuthUsers: (
+        ...args: TaskNameToParams<'listAuthUsers'>
+      ) => Cypress.Chainable<auth.ListUsersResult>;
 
       /**
        * Login to Firebase auth as a user with either a passed uid or the TEST_UID
@@ -364,7 +366,9 @@ declare global {
        * @example
        * cy.getAuthUser('1234')
        */
-      getAuthUser: (...args: TaskNameToParams<'getAuthUser'>) => Chainable;
+      getAuthUser: (
+        ...args: TaskNameToParams<'getAuthUser'>
+      ) => Chainable<auth.UserRecord | null>;
       /**
        * Get Firebase auth user by email
        * @param email - Email of user to get
@@ -377,7 +381,7 @@ declare global {
        */
       getAuthUserByEmail: (
         ...args: TaskNameToParams<'getAuthUserByEmail'>
-      ) => Chainable;
+      ) => Chainable<auth.UserRecord | null>;
       /**
        * Get Firebase auth user by phone number
        * @param phoneNumber - Phone number of user to get
@@ -390,7 +394,7 @@ declare global {
        */
       getAuthUserByPhoneNumber: (
         ...args: TaskNameToParams<'getAuthUserByPhoneNumber'>
-      ) => Chainable;
+      ) => Chainable<auth.UserRecord | null>;
       /**
        * Get Firebase auth user by providerID and UID
        * @param providerId - Provider ID of user to get
@@ -404,7 +408,7 @@ declare global {
        */
       getAuthUserByProviderUid: (
         ...args: TaskNameToParams<'getAuthUserByProviderUid'>
-      ) => Chainable;
+      ) => Chainable<auth.UserRecord | null>;
 
       /**
        * Get Firebase Auth users based on identifiers
@@ -416,7 +420,9 @@ declare global {
        * @example
        * cy.getAuthUsers([{email: 'foobar@mail.com'}, {uid: "1234"}])
        */
-      getAuthUsers: (...args: TaskNameToParams<'getAuthUsers'>) => Chainable;
+      getAuthUsers: (
+        ...args: TaskNameToParams<'getAuthUsers'>
+      ) => Chainable<auth.GetUsersResult>;
 
       /**
        * Update an existing Firebase Auth user
@@ -431,7 +437,7 @@ declare global {
        */
       updateAuthUser: (
         ...args: TaskNameToParams<'updateAuthUser'>
-      ) => Chainable;
+      ) => Chainable<auth.UserRecord>;
       /**
        * Set custom claims of an existing Firebase Auth user
        * @param uid - UID of the user to edit
@@ -445,7 +451,7 @@ declare global {
        */
       setAuthUserClaims: (
         ...args: TaskNameToParams<'setAuthUserCustomClaims'>
-      ) => Chainable;
+      ) => Chainable<null>;
 
       /**
        * Delete a user from Firebase Auth with either a passed uid or the TEST_UID
@@ -460,7 +466,7 @@ declare global {
        */
       deleteAuthUser: (
         ...args: TaskNameToParams<'deleteAuthUser'>
-      ) => Chainable;
+      ) => Chainable<null>;
       /**
        * Delete a user from Firebase Auth with either a passed uid or the TEST_UID
        * environment variable
@@ -474,7 +480,7 @@ declare global {
        */
       deleteAuthUsers: (
         ...args: TaskNameToParams<'deleteAuthUsers'>
-      ) => Chainable;
+      ) => Chainable<auth.DeleteUsersResult>;
       /**
        * Delete all users from Firebase Auth
        * Resolves when all users have been deleted
@@ -486,7 +492,7 @@ declare global {
        * @example
        * cy.deleteAllAuthUsers()
        */
-      deleteAllAuthUsers: (tenantId?: string) => Chainable;
+      deleteAllAuthUsers: (tenantId?: string) => Chainable<void>;
 
       /**
        * Create a custom token for a user
@@ -501,7 +507,7 @@ declare global {
        */
       createCustomToken: (
         ...args: TaskNameToParams<'createCustomToken'>
-      ) => Chainable;
+      ) => Chainable<string>;
       /**
        * Create a session cookie for a user
        * @param idToken - ID token to create session cookie for
@@ -515,7 +521,7 @@ declare global {
        */
       createSessionCookie: (
         ...args: TaskNameToParams<'createSessionCookie'>
-      ) => Chainable;
+      ) => Chainable<string>;
       /**
        * Verify an ID token
        * @param idToken - ID token to verify
@@ -527,7 +533,9 @@ declare global {
        * @example
        * cy.verifyIdToken(idToken)
        */
-      verifyIdToken: (...args: TaskNameToParams<'verifyIdToken'>) => Chainable;
+      verifyIdToken: (
+        ...args: TaskNameToParams<'verifyIdToken'>
+      ) => Chainable<auth.DecodedIdToken>;
       /**
        * Revoke all refresh tokens for a user
        * @param uid - UID of user to revoke refresh tokens for
@@ -540,7 +548,7 @@ declare global {
        */
       revokeRefreshTokens: (
         ...args: TaskNameToParams<'revokeRefreshTokens'>
-      ) => Chainable;
+      ) => Chainable<void>;
       /**
        * Generate an email verification link
        * @param email - Email to generate verification link for
@@ -554,7 +562,7 @@ declare global {
        */
       generateEmailVerificationLink: (
         ...args: TaskNameToParams<'generateEmailVerificationLink'>
-      ) => Chainable;
+      ) => Chainable<string>;
       /**
        * Generate a password reset link
        * @param email - Email to generate password reset link for
@@ -568,7 +576,7 @@ declare global {
        */
       generatePasswordResetLink: (
         ...args: TaskNameToParams<'generatePasswordResetLink'>
-      ) => Chainable;
+      ) => Chainable<string>;
       /**
        * Generate a sign in with email link
        * @param email - Email to generate sign in link for
@@ -582,7 +590,7 @@ declare global {
        */
       generateSignInWithEmailLink: (
         ...args: TaskNameToParams<'generateSignInWithEmailLink'>
-      ) => Chainable;
+      ) => Chainable<string>;
 
       /**
        * Generate a verify and change email link
@@ -598,7 +606,7 @@ declare global {
        */
       generateVerifyAndChangeEmailLink: (
         ...args: TaskNameToParams<'generateVerifyAndChangeEmailLink'>
-      ) => Chainable;
+      ) => Chainable<string>;
 
       /**
        * Create a provider config
@@ -612,7 +620,7 @@ declare global {
        */
       createProviderConfig: (
         ...args: TaskNameToParams<'createProviderConfig'>
-      ) => Chainable;
+      ) => Chainable<auth.AuthProviderConfig>;
       /**
        * Get a provider config
        * @param providerId - The provider ID to get the config for
@@ -625,7 +633,7 @@ declare global {
        */
       getProviderConfig: (
         ...args: TaskNameToParams<'getProviderConfig'>
-      ) => Chainable;
+      ) => Chainable<auth.AuthProviderConfig>;
       /**
        * List provider configs
        * @param providerFilter - The provider ID to filter by, or null to list all
@@ -638,7 +646,7 @@ declare global {
        */
       listProviderConfigs: (
         ...args: TaskNameToParams<'listProviderConfigs'>
-      ) => Chainable;
+      ) => Chainable<auth.ListProviderConfigResults>;
       /**
        * Update a provider config
        * @param providerId - The provider ID to update the config for
@@ -652,7 +660,7 @@ declare global {
        */
       updateProviderConfig: (
         ...args: TaskNameToParams<'updateProviderConfig'>
-      ) => Chainable;
+      ) => Chainable<auth.AuthProviderConfig>;
       /**
        * Delete a provider config
        * @param providerId - The provider ID to delete the config for
@@ -665,7 +673,7 @@ declare global {
        */
       deleteProviderConfig: (
         ...args: TaskNameToParams<'deleteProviderConfig'>
-      ) => Chainable;
+      ) => Chainable<null>;
     }
   }
 }
@@ -748,7 +756,7 @@ function deleteAllAuthUsers(
   cy: AttachCustomCommandParams['cy'],
   tenantId?: string | undefined,
   pageToken?: string,
-): Promise<any> {
+): Promise<void> {
   return new Promise<void>((resolve, reject): any => {
     typedTask(cy, 'listAuthUsers', { tenantId, pageToken }).then(
       ({ users, pageToken: nextPageToken }) => {
@@ -926,7 +934,7 @@ export default function attachCustomCommands(
       properties: auth.CreateRequest,
       customClaims?: object | null,
       tenantId: string = Cypress.env('TEST_TENANT_ID'),
-    ): any =>
+    ) =>
       typedTask(cy, 'createAuthUser', { properties, tenantId }).then((user) => {
         if (user === 'auth/email-already-exists') {
           if (!properties.email) {
@@ -1202,7 +1210,7 @@ export default function attachCustomCommands(
     (
       uid?: string,
       tenantId: string | undefined = Cypress.env('TEST_TENANT_ID'),
-    ): any => {
+    ) => {
       const userUid = uid ?? Cypress.env('TEST_UID');
       // Handle UID which is passed in
       if (!userUid) {
@@ -1226,7 +1234,7 @@ export default function attachCustomCommands(
 
   Cypress.Commands.add(
     options?.commandNames?.deleteAllAuthUsers ?? 'deleteAllAuthUsers',
-    (tenantId: string | undefined = Cypress.env('TEST_TENANT_ID')): any =>
+    (tenantId: string | undefined = Cypress.env('TEST_TENANT_ID')) =>
       cy.wrap(deleteAllAuthUsers(cy, tenantId)),
   );
 

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -1,4 +1,5 @@
-import type { firestore } from 'firebase-admin';
+import type { auth, firestore } from 'firebase-admin';
+import { typedTask, type createAuthUser, TaskNameToParams } from './tasks';
 
 /**
  * Params for attachCustomCommand function for
@@ -168,29 +169,6 @@ declare global {
     /* eslint-enable @typescript-eslint/no-namespace,@typescript-eslint/no-unused-vars */
     interface Chainable {
       /**
-       * Login to Firebase auth as a user with either a passed uid or the TEST_UID
-       * environment variable. A custom auth token is generated using firebase-admin
-       * authenticated with serviceAccount.json or SERVICE_ACCOUNT env var.
-       * @see https://github.com/prescottprue/cypress-firebase#cylogin
-       * @param uid - UID of user to login as
-       * @param customClaims - Custom claims to attach to the custom token
-       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also be set with environment variable TEST_TENANT_ID
-       * @example <caption>Env Based Login (TEST_UID)</caption>
-       * cy.login()
-       * @example <caption>Passed UID</caption>
-       * cy.login('123SOMEUID')
-       */
-      login: (uid?: string, customClaims?: any, tenantId?: string) => Chainable;
-
-      /**
-       * Log current user out of Firebase Auth
-       * @see https://github.com/prescottprue/cypress-firebase#cylogout
-       * @example
-       * cy.logout()
-       */
-      logout: () => Chainable;
-
-      /**
        * Call Real Time Database path with some specified action. Authentication is through
        * `FIREBASE_TOKEN` (CI token) since firebase-tools is used under the hood, allowing
        * for admin privileges.
@@ -231,7 +209,6 @@ declare global {
         deletePath: string,
         options?: CallFirestoreOptions,
       ): Chainable;
-
       /**
        * Set, or add a document to Firestore. Authentication is through serviceAccount.json or SERVICE_ACCOUNT
        * environment variable.
@@ -256,7 +233,6 @@ declare global {
         data: firestore.PartialWithFieldValue<T>,
         options?: CallFirestoreOptions,
       ): Chainable;
-
       /**
        * Update an existing document in Firestore. Authentication is through serviceAccount.json or SERVICE_ACCOUNT
        * environment variable.
@@ -271,7 +247,6 @@ declare global {
         data: firestore.UpdateData<T>,
         options?: CallFirestoreOptions,
       ): Chainable;
-
       /**
        * Get an existing document from Firestore. Authentication is through serviceAccount.json or SERVICE_ACCOUNT
        * environment variable.
@@ -289,6 +264,408 @@ declare global {
         getPath: string,
         options?: CallFirestoreOptions,
       ): Chainable;
+
+      /**
+       * Create a Firebase Auth user
+       * @param properties - The properties to set on the new user record to be created
+       * @param customClaims - Custom claims to attach to the new user
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.createAuthUser
+       * @see https://github.com/prescottprue/cypress-firebase#cycreateauthuser
+       * cy.createAuthUser()
+       */
+      createAuthUser: (
+        properties: auth.CreateRequest,
+        customClaims?: object | null,
+        tenantId?: string,
+      ) => Chainable;
+
+      /**
+       * Import list of Firebase Auth users
+       * @param usersImport - The list of user records to import to Firebase Auth
+       * @param importOptions - Optional options for the user import
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.importAuthUsers
+       * @see https://github.com/prescottprue/cypress-firebase#cyimportauthusers
+       * @example
+       * cy.importAuthUsers()
+       */
+      importAuthUsers: (
+        ...args: TaskNameToParams<'importAuthUsers'>
+      ) => Chainable;
+
+      /**
+       * List Firebase Auth users
+       * @param maxResults - The page size, 1000 if undefined
+       * @param pageToken - The next page token
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.listAuthUsers
+       * @see https://github.com/prescottprue/cypress-firebase#cylistauthusers
+       * @example
+       * cy.listAuthUsers()
+       */
+      listAuthUsers: (...args: TaskNameToParams<'listAuthUsers'>) => Chainable;
+
+      /**
+       * Login to Firebase auth as a user with either a passed uid or the TEST_UID
+       * environment variable. A custom auth token is generated using firebase-admin
+       * authenticated with serviceAccount.json or SERVICE_ACCOUNT env var.
+       * @see https://github.com/prescottprue/cypress-firebase#cylogin
+       * @param uid - UID of user to login as
+       * @param customClaims - Custom claims to attach to the custom token
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @example <caption>Env Based Login (TEST_UID)</caption>
+       * cy.login()
+       * @example <caption>Passed UID</caption>
+       * cy.login('123SOMEUID')
+       */
+      login: (uid?: string, customClaims?: any, tenantId?: string) => Chainable;
+
+      /**
+       * Login to Firebase auth using email and password user with either a passed
+       * email and password or the TEST_EMAIL and TEST_PASSWORD environment variables.
+       * Authentication happens with serviceAccount.json or SERVICE_ACCOUNT env var.
+       * @see https://github.com/prescottprue/cypress-firebase#cyloginwithemailandpassword
+       * @param email - email of user to login as
+       * @param password - password of user to login as
+       * @param customClaims - Custom claims to attach to the custom token
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also be set with environment variable TEST_TENANT_ID
+       * @example <caption>Env Based Login (TEST_EMAIL, TEST_PASSWORD)</caption>
+       * cy.loginWithEmailAndPassword()
+       * @example <caption>Passed email and password</caption>
+       * cy.login('some@user.com', 'password123')
+       */
+      loginWithEmailAndPassword: (
+        email?: string,
+        password?: string,
+        customClaims?: any,
+        tenantId?: string,
+      ) => Chainable;
+
+      /**
+       * Log current user out of Firebase Auth
+       * @see https://github.com/prescottprue/cypress-firebase#cylogout
+       * @example
+       * cy.logout()
+       */
+      logout: () => Chainable;
+
+      /**
+       * Get Firebase auth user by UID
+       * @param uid - UID of user to get
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.getAuthUser
+       * @see https://github.com/prescottprue/cypress-firebase#cygetauthuser
+       * @example
+       * cy.getAuthUser('1234')
+       */
+      getAuthUser: (...args: TaskNameToParams<'getAuthUser'>) => Chainable;
+      /**
+       * Get Firebase auth user by email
+       * @param email - Email of user to get
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.getAuthUserByEmail
+       * @see https://github.com/prescottprue/cypress-firebase#cygetauthuserbyemail
+       * @example
+       * cy.getAuthUserByEmail('foobar@mail.com')
+       */
+      getAuthUserByEmail: (
+        ...args: TaskNameToParams<'getAuthUserByEmail'>
+      ) => Chainable;
+      /**
+       * Get Firebase auth user by phone number
+       * @param phoneNumber - Phone number of user to get
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.getAuthUserByPhoneNumber
+       * @see https://github.com/prescottprue/cypress-firebase#cygetauthuserbyphonenumber
+       * @example
+       * cy.getAuthUserByPhoneNumber('1234567890')
+       */
+      getAuthUserByPhoneNumber: (
+        ...args: TaskNameToParams<'getAuthUserByPhoneNumber'>
+      ) => Chainable;
+      /**
+       * Get Firebase auth user by providerID and UID
+       * @param providerId - Provider ID of user to get
+       * @param uid - UID of user to get
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.getAuthUserByProviderUid
+       * @see https://github.com/prescottprue/cypress-firebase#cygetauthuserbyprovideruid
+       * @example
+       * cy.getAuthUserByProviderUid(providerId, uid)
+       */
+      getAuthUserByProviderUid: (
+        ...args: TaskNameToParams<'getAuthUserByProviderUid'>
+      ) => Chainable;
+
+      /**
+       * Get Firebase Auth users based on identifiers
+       * @param adminInstance - Admin SDK instance
+       * @param identifiers - The identifiers used to indicate which user records should be returned.
+       * @param tenantId - Optional ID of tenant used for multi-tenancy
+       * @returns Promise which resolves with a GetUsersResult object
+       * @see https://github.com/prescottprue/cypress-firebase#cygetauthusers
+       * @example
+       * cy.getAuthUsers([{email: 'foobar@mail.com'}, {uid: "1234"}])
+       */
+      getAuthUsers: (...args: TaskNameToParams<'getAuthUsers'>) => Chainable;
+
+      /**
+       * Update an existing Firebase Auth user
+       * @param uid - UID of the user to edit
+       * @param properties - The properties to update on the user
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.updateAuthUser
+       * @see https://github.com/prescottprue/cypress-firebase#cyupdateauthuser
+       * @example
+       * cy.updateAuthUser(uid, {displayName: "New Name"})
+       */
+      updateAuthUser: (
+        ...args: TaskNameToParams<'updateAuthUser'>
+      ) => Chainable;
+      /**
+       * Set custom claims of an existing Firebase Auth user
+       * @param uid - UID of the user to edit
+       * @param customClaims - The custom claims to set, null deletes the custom claims
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.setAuthUserClaims
+       * @see https://github.com/prescottprue/cypress-firebase#cysetauthuserclaims
+       * @example
+       * cy.setUserClaims(uid, {some: 'claim'})
+       */
+      setAuthUserClaims: (
+        ...args: TaskNameToParams<'setAuthUserCustomClaims'>
+      ) => Chainable;
+
+      /**
+       * Delete a user from Firebase Auth with either a passed uid or the TEST_UID
+       * environment variable
+       * @param uid = UID of user to delete
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.deleteAuthUser
+       * @see https://github.com/prescottprue/cypress-firebase#cydeleteauthuser
+       * @example
+       * cy.deleteAuthUser(uid)
+       */
+      deleteAuthUser: (
+        ...args: TaskNameToParams<'deleteAuthUser'>
+      ) => Chainable;
+      /**
+       * Delete a user from Firebase Auth with either a passed uid or the TEST_UID
+       * environment variable
+       * @param uid = UID of user to delete
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.deleteAllAuthUsers
+       * @see https://github.com/prescottprue/cypress-firebase#cydeleteauthusers
+       * @example
+       * cy.deleteAuthUsers([uid1, uid2])
+       */
+      deleteAuthUsers: (
+        ...args: TaskNameToParams<'deleteAuthUsers'>
+      ) => Chainable;
+      /**
+       * Delete all users from Firebase Auth
+       * Resolves when all users have been deleted
+       * Rejects if too many deletes fail or all deletes failed
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.deleteAllAuthUsers
+       * @see https://github.com/prescottprue/cypress-firebase#cydeleteallauthusers
+       * @example
+       * cy.deleteAllAuthUsers()
+       */
+      deleteAllAuthUsers: (tenantId?: string) => Chainable;
+
+      /**
+       * Create a custom token for a user
+       * @param uid - UID of the user to create a custom token for
+       * @param customClaims - Custom claims to attach to the custom token
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.createCustomToken
+       * @see https://github.com/prescottprue/cypress-firebase#cycreatecustomtoken
+       * @example
+       * cy.createCustomToken(uid)
+       */
+      createCustomToken: (
+        ...args: TaskNameToParams<'createCustomToken'>
+      ) => Chainable;
+      /**
+       * Create a session cookie for a user
+       * @param idToken - ID token to create session cookie for
+       * @param sessionCookieOptions - Options for the session cookie
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.createSessionCookie
+       * @see https://github.com/prescottprue/cypress-firebase#cycreatesessioncookie
+       * @example
+       * cy.createSessionCookie(idToken)
+       */
+      createSessionCookie: (
+        ...args: TaskNameToParams<'createSessionCookie'>
+      ) => Chainable;
+      /**
+       * Verify an ID token
+       * @param idToken - ID token to verify
+       * @param checkRevoked - Whether to check if the token has been revoked
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.verifyIdToken
+       * @see https://github.com/prescottprue/cypress-firebase#cyverifyidtoken
+       * @example
+       * cy.verifyIdToken(idToken)
+       */
+      verifyIdToken: (...args: TaskNameToParams<'verifyIdToken'>) => Chainable;
+      /**
+       * Revoke all refresh tokens for a user
+       * @param uid - UID of user to revoke refresh tokens for
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.revokeRefreshTokens
+       * @see https://github.com/prescottprue/cypress-firebase#cyrevokerefreshtokens
+       * @example
+       * cy.revokeRefreshTokens(uid)
+       */
+      revokeRefreshTokens: (
+        ...args: TaskNameToParams<'revokeRefreshTokens'>
+      ) => Chainable;
+      /**
+       * Generate an email verification link
+       * @param email - Email to generate verification link for
+       * @param actionCodeSettings - Action code settings for the email
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.generateEmailVerificationLink
+       * @see https://github.com/prescottprue/cypress-firebase#cygenerateemailverificationlink
+       * @example
+       * cy.generateEmailVerificationLink(email)
+       */
+      generateEmailVerificationLink: (
+        ...args: TaskNameToParams<'generateEmailVerificationLink'>
+      ) => Chainable;
+      /**
+       * Generate a password reset link
+       * @param email - Email to generate password reset link for
+       * @param actionCodeSettings - Action code settings for the email
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.generatePasswordResetLink
+       * @see https://github.com/prescottprue/cypress-firebase#cygeneratepasswordresetlink
+       * @example
+       * cy.generatePasswordResetLink(email)
+       */
+      generatePasswordResetLink: (
+        ...args: TaskNameToParams<'generatePasswordResetLink'>
+      ) => Chainable;
+      /**
+       * Generate a sign in with email link
+       * @param email - Email to generate sign in link for
+       * @param actionCodeSettings - Action code settings for the email
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.generateSignInWithEmailLink
+       * @see https://github.com/prescottprue/cypress-firebase#cygeneratesigninwithemaillink
+       * @example
+       * cy.generateSignInWithEmailLink(email, actionCodeSettings)
+       */
+      generateSignInWithEmailLink: (
+        ...args: TaskNameToParams<'generateSignInWithEmailLink'>
+      ) => Chainable;
+
+      /**
+       * Generate a verify and change email link
+       * @param email - Email to generate verify and change email link for
+       * @param newEmail - New email to change to
+       * @param actionCodeSettings - Action code settings for the email
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.generateVerifyAndChangeEmailLink
+       * @see https://github.com/prescottprue/cypress-firebase#cygenerateverifyandchangeemaillink
+       * @example
+       * cy.generateVerifyAndChangeEmailLink(oldEmail, newEmail)
+       */
+      generateVerifyAndChangeEmailLink: (
+        ...args: TaskNameToParams<'generateVerifyAndChangeEmailLink'>
+      ) => Chainable;
+
+      /**
+       * Create a provider config
+       * @param providerConfig - The provider config to create
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.createProviderConfig
+       * @see https://github.com/prescottprue/cypress-firebase#cycreateproviderconfig
+       * @example
+       * cy.createProviderConfig(providerConfig)
+       */
+      createProviderConfig: (
+        ...args: TaskNameToParams<'createProviderConfig'>
+      ) => Chainable;
+      /**
+       * Get a provider config
+       * @param providerId - The provider ID to get the config for
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.getProviderConfig
+       * @see https://github.com/prescottprue/cypress-firebase#cygetproviderconfig
+       * @example
+       * cy.getProviderConfig(providerId)
+       */
+      getProviderConfig: (
+        ...args: TaskNameToParams<'getProviderConfig'>
+      ) => Chainable;
+      /**
+       * List provider configs
+       * @param providerFilter - The provider ID to filter by, or null to list all
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.listProviderConfigs
+       * @see https://github.com/prescottprue/cypress-firebase#cylistproviderconfigs
+       * @example
+       * cy.listProviderConfigs(providerFilter)
+       */
+      listProviderConfigs: (
+        ...args: TaskNameToParams<'listProviderConfigs'>
+      ) => Chainable;
+      /**
+       * Update a provider config
+       * @param providerId - The provider ID to update the config for
+       * @param providerConfig - The provider config to update to
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.updateProviderConfig
+       * @see https://github.com/prescottprue/cypress-firebase#cyupdateproviderconfig
+       * @example
+       * cy.updateProviderConfig(providerId, providerConfig)
+       */
+      updateProviderConfig: (
+        ...args: TaskNameToParams<'updateProviderConfig'>
+      ) => Chainable;
+      /**
+       * Delete a provider config
+       * @param providerId - The provider ID to delete the config for
+       * @param tenantId - Optional ID of tenant used for multi-tenancy. Can also
+       * be set with environment variable TEST_TENANT_ID
+       * @name cy.deleteProviderConfig
+       * @see https://github.com/prescottprue/cypress-firebase#cydeleteproviderconfig
+       * @example
+       * cy.deleteProviderConfig(providerId)
+       */
+      deleteProviderConfig: (
+        ...args: TaskNameToParams<'deleteProviderConfig'>
+      ) => Chainable;
     }
   }
 }
@@ -336,13 +713,100 @@ function loginWithCustomToken(auth: any, customToken: string): Promise<any> {
   });
 }
 
-interface CommandNamespacesConfig {
-  login?: string;
-  logout?: string;
-  callRtdb?: string;
-  callFirestore?: string;
-  getAuthUser?: string;
+/**
+ * @param auth - firebase auth instance
+ * @param email - email to use for login
+ * @param password - password to use for login
+ * @returns Promise which resolves with the user auth object
+ */
+function loginWithEmailAndPassword(
+  auth: any,
+  email: string,
+  password: string,
+): Promise<any> {
+  return new Promise((resolve, reject): any => {
+    auth.onAuthStateChanged((auth: any) => {
+      if (auth) {
+        resolve(auth);
+      }
+    });
+    auth.signInWithEmailAndPassword(email, password).catch(reject);
+  });
 }
+
+/**
+ * Delete all users from Firebase Auth, recursively because of batch
+ * size limitations
+ * Resolves when all users have been deleted
+ * Rejects if too many deletes fail or all deletes failed
+ * @param cy - Cypress object
+ * @param tenantId - Tenant ID to use for user deletion
+ * @param pageToken - Page token used for recursion
+ * @returns Promise which resolves when all users have been deleted
+ */
+function deleteAllAuthUsers(
+  cy: AttachCustomCommandParams['cy'],
+  tenantId?: string | undefined,
+  pageToken?: string,
+): Promise<any> {
+  return new Promise<void>((resolve, reject): any => {
+    typedTask(cy, 'listAuthUsers', { tenantId, pageToken }).then(
+      ({ users, pageToken: nextPageToken }) => {
+        if (users.length === 0) resolve();
+        else {
+          const uids = users.map((user) => user.uid);
+          typedTask(cy, 'deleteAuthUsers', { uids, tenantId }).then(
+            ({ successCount, failureCount }) => {
+              if (failureCount > successCount || successCount === 0)
+                reject(
+                  new Error(
+                    `Too many deletes failed. ${successCount} users were deleted, ${failureCount} failed.`,
+                  ),
+                );
+              deleteAllAuthUsers(cy, tenantId, nextPageToken).then(resolve);
+            },
+          );
+        }
+      },
+    );
+  });
+}
+
+type CommandNames =
+  | 'callRtdb'
+  | 'callFirestore'
+  | 'createAuthUser'
+  | 'importAuthUsers'
+  | 'listAuthUsers'
+  | 'login'
+  | 'loginWithEmailAndPassword'
+  | 'logout'
+  | 'getAuthUser'
+  | 'getAuthUserByEmail'
+  | 'getAuthUserByPhoneNumber'
+  | 'getAuthUserByProviderUid'
+  | 'updateAuthUser'
+  | 'setAuthUserClaims'
+  | 'deleteAuthUser'
+  | 'deleteAuthUsers'
+  | 'deleteAllAuthUsers'
+  | 'createCustomToken'
+  | 'createSessionCookie'
+  | 'verifyIdToken'
+  | 'revokeRefreshTokens'
+  | 'generateEmailVerificationLink'
+  | 'generatePasswordResetLink'
+  | 'generateSignInWithEmailLink'
+  | 'generateVerifyAndChangeEmailLink'
+  | 'createProviderConfig'
+  | 'getProviderConfig'
+  | 'listProviderConfigs'
+  | 'updateProviderConfig'
+  | 'deleteProviderConfig';
+
+type CommandNamespacesConfig = {
+  [N in CommandNames]?: string | boolean;
+};
 
 interface CustomCommandOptions {
   commandNames?: CommandNamespacesConfig;
@@ -361,7 +825,7 @@ export default function attachCustomCommands(
 ): void {
   const { Cypress, cy, firebase, app } = context;
 
-  const defaultApp = app || firebase.app(); // select default  app
+  const defaultApp = app ?? firebase.app(); // select default  app
 
   /**
    * Get firebase auth instance, with tenantId set if provided
@@ -376,86 +840,8 @@ export default function attachCustomCommands(
     return auth;
   }
 
-  /**
-   * Login to Firebase auth as a user with either a passed uid or the TEST_UID
-   * environment variable. A custom auth token is generated using firebase-admin
-   * authenticated with serviceAccount.json or SERVICE_ACCOUNT env var.
-   * @name cy.login
-   */
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.login) || 'login',
-    (
-      uid?: string,
-      customClaims?: any,
-      tenantId: string | undefined = Cypress.env('TEST_TENANT_ID'),
-    ): any => {
-      const userUid = uid || Cypress.env('TEST_UID');
-      // Handle UID which is passed in
-      if (!userUid) {
-        throw new Error(
-          'uid must be passed or TEST_UID set within environment to login',
-        );
-      }
-      const auth = getAuth(tenantId);
-      // Resolve with current user if they already exist
-      if (auth.currentUser && userUid === auth.currentUser.uid) {
-        cy.log('Authed user already exists, login complete.');
-        return undefined;
-      }
-
-      cy.log('Creating custom token for login...');
-
-      // Generate a custom token using createCustomToken task (if tasks are enabled) then login
-      return cy
-        .task('createCustomToken', {
-          uid: userUid,
-          customClaims,
-          tenantId,
-        })
-        .then((customToken: string) => loginWithCustomToken(auth, customToken));
-    },
-  );
-
-  /**
-   * Log out of Firebase instance
-   * @name cy.logout
-   * @see https://github.com/prescottprue/cypress-firebase#cylogout
-   * @example
-   * cy.logout()
-   */
-  Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.logout) ||
-      'logout',
-    (
-      tenantId: string | undefined = Cypress.env('TEST_TENANT_ID'),
-    ): Promise<any> =>
-      new Promise(
-        (
-          resolve: (value?: any) => void,
-          reject: (reason?: any) => void,
-        ): any => {
-          const auth = getAuth(tenantId);
-          auth.onAuthStateChanged((auth: any) => {
-            if (!auth) {
-              resolve();
-            }
-          });
-          auth.signOut().catch(reject);
-        },
-      ),
-  );
-
-  /**
-   * Call Real Time Database path with some specified action. Leverages callRtdb
-   * Cypress task which calls through firebase-admin.
-   * @param action - The action type to call with (set, push, update, remove)
-   * @param actionPath - Path within RTDB that action should be applied
-   * @param options - Options
-   * @name cy.callRtdb
-   */
-  Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.callRtdb) ||
-      'callRtdb',
+    options?.commandNames?.callRtdb ?? 'callRtdb',
     (
       action: RTDBAction,
       actionPath: string,
@@ -473,7 +859,7 @@ export default function attachCustomCommands(
         const dataToWrite = dataIsObject ? { ...dataOrOptions } : dataOrOptions;
 
         // Add metadata to dataToWrite if specified by options
-        if (dataIsObject && options && options.withMeta) {
+        if (dataIsObject && options?.withMeta) {
           if (!dataToWrite.createdBy && Cypress.env('TEST_UID')) {
             dataToWrite.createdBy = Cypress.env('TEST_UID');
           }
@@ -494,17 +880,8 @@ export default function attachCustomCommands(
     },
   );
 
-  /**
-   * Call Firestore instance with some specified action.  Leverages callFirestore
-   * Cypress task which calls through firebase-admin.
-   * @param action - The action type to call with (set, push, update, remove)
-   * @param actionPath - Path within RTDB that action should be applied
-   * @param options - Options
-   * @name cy.callFirestore
-   */
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.callFirestore) ||
-      'callFirestore',
+    options?.commandNames?.callFirestore ?? 'callFirestore',
     (
       action: FirestoreAction,
       actionPath: string,
@@ -522,7 +899,7 @@ export default function attachCustomCommands(
         const dataToWrite = dataIsObject ? { ...dataOrOptions } : dataOrOptions;
 
         // Add metadata to dataToWrite if specified by options
-        if (dataIsObject && options && options.withMeta) {
+        if (dataIsObject && options?.withMeta) {
           if (!dataToWrite.createdBy) {
             dataToWrite.createdBy = Cypress.env('TEST_UID');
           }
@@ -543,16 +920,443 @@ export default function attachCustomCommands(
     },
   );
 
-  /**
-   * Get Firebase auth user by UID
-   * @name cy.getAuthUser
-   * @see https://github.com/prescottprue/cypress-firebase#cygetauthuser
-   * @example
-   * cy.getAuthUser()
-   */
   Cypress.Commands.add(
-    (options && options.commandNames && options.commandNames.getAuthUser) ||
-      'getAuthUser',
-    (uid: string): Promise<any> => cy.task('getAuthUser', uid),
+    options?.commandNames?.createAuthUser ?? 'createAuthUser',
+    (
+      properties: auth.CreateRequest,
+      customClaims?: object | null,
+      tenantId: string = Cypress.env('TEST_TENANT_ID'),
+    ): any =>
+      typedTask(cy, 'createAuthUser', { properties, tenantId }).then((user) => {
+        if (customClaims !== undefined && user) {
+          return typedTask(cy, 'setAuthUserCustomClaims', {
+            uid: user.uid,
+            customClaims,
+            tenantId,
+          }).then(() => user.uid);
+        }
+        return user?.uid;
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.importAuthUsers ?? 'importAuthUsers',
+    (...args: TaskNameToParams<'importAuthUsers'>) =>
+      typedTask(cy, 'importAuthUsers', {
+        usersImport: args[0],
+        importOptions: args[1],
+        tenantId: args[2] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.listAuthUsers ?? 'listAuthUsers',
+    (...args: TaskNameToParams<'listAuthUsers'>) =>
+      typedTask(cy, 'listAuthUsers', {
+        maxResults: args[0],
+        pageToken: args[1],
+        tenantId: args[2] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.login ?? 'login',
+    (
+      uid?: string,
+      customClaims?: any,
+      tenantId: string | undefined = Cypress.env('TEST_TENANT_ID'),
+    ): any => {
+      const userUid = uid ?? Cypress.env('TEST_UID');
+      // Handle UID which is passed in
+      if (!userUid) {
+        throw new Error(
+          'uid must be passed or TEST_UID set within environment to login',
+        );
+      }
+      const auth = getAuth(tenantId);
+      // Resolve with current user if they already exist
+      if (userUid === auth.currentUser?.uid) {
+        cy.log('Authed user already exists, login complete.');
+        return undefined;
+      }
+
+      cy.log('Creating custom token for login...');
+
+      // Generate a custom token using createCustomToken task (if tasks are enabled) then login
+      return typedTask(cy, 'createCustomToken', {
+        uid: userUid,
+        customClaims,
+        tenantId,
+      }).then((customToken) => loginWithCustomToken(auth, customToken));
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.loginWithEmailAndPassword ??
+      'loginWithEmailAndPassword',
+    (
+      email?: string,
+      password?: string,
+      extraInfo?: Omit<
+        Parameters<typeof createAuthUser>[1],
+        'email' | 'password'
+      >,
+      tenantId: string | undefined = Cypress.env('TEST_TENANT_ID'),
+    ): any => {
+      const userUid = Cypress.env('TEST_UID');
+      const userEmail = email ?? Cypress.env('TEST_EMAIL');
+      // Handle email which is passed in
+      if (!userEmail) {
+        throw new Error(
+          'email must be passed or TEST_EMAIL set within environment to login',
+        );
+      }
+      const userPassword = password ?? Cypress.env('TEST_PASSWORD');
+      // Handle password which is passed in
+      if (!userPassword) {
+        throw new Error(
+          'password must be passed or TEST_PASSWORD set within environment to login',
+        );
+      }
+      const auth = getAuth(tenantId);
+      // Resolve with current user if they already exist
+      if (userEmail === auth.currentUser?.email) {
+        cy.log('Authed user already exists, login complete.');
+        return undefined;
+      }
+      return typedTask(cy, 'getAuthUserByEmail', {
+        email: userEmail,
+        tenantId,
+      }).then((user) => {
+        if (user)
+          return loginWithEmailAndPassword(auth, userEmail, userPassword);
+        typedTask(cy, 'createAuthUser', {
+          properties: {
+            uid: userUid,
+            email: userEmail,
+            password: userPassword,
+            ...extraInfo,
+          },
+          tenantId,
+        });
+        return cy
+          .task('createAuthUser', {
+            properties: {
+              email: userEmail,
+              password: userPassword,
+              ...extraInfo,
+            },
+            tenantId,
+          })
+          .then(() => loginWithEmailAndPassword(auth, userEmail, userPassword));
+      });
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.logout ?? 'logout',
+    (
+      tenantId: string | undefined = Cypress.env('TEST_TENANT_ID'),
+    ): Promise<any> =>
+      new Promise(
+        (
+          resolve: (value?: any) => void,
+          reject: (reason?: any) => void,
+        ): any => {
+          const auth = getAuth(tenantId);
+          auth.onAuthStateChanged((auth: any) => {
+            if (!auth) {
+              resolve();
+            }
+          });
+          auth.signOut().catch(reject);
+        },
+      ),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.getAuthUser ?? 'getAuthUser',
+    (uid?: string, tenantId?: string) => {
+      const userUid = uid ?? Cypress.env('TEST_UID');
+      // Handle UID which is passed in
+      if (!userUid) {
+        throw new Error(
+          'uid must be passed or TEST_UID set within environment to login',
+        );
+      }
+      return typedTask(cy, 'getAuthUser', {
+        uid: userUid,
+        tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      });
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.getAuthUserByEmail ?? 'getAuthUserByEmail',
+    (email?: string, tenantId?: string) => {
+      const userEmail = email ?? Cypress.env('TEST_EMAIL');
+      // Handle email which is passed in
+      if (!userEmail) {
+        throw new Error(
+          'email must be passed or TEST_EMAIL set within environment to login',
+        );
+      }
+      return typedTask(cy, 'getAuthUserByEmail', {
+        email: userEmail,
+        tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      });
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.getAuthUserByPhoneNumber ??
+      'getAuthUserByPhoneNumber',
+    (...args: TaskNameToParams<'getAuthUserByPhoneNumber'>) =>
+      typedTask(cy, 'getAuthUserByPhoneNumber', {
+        phoneNumber: args[0],
+        tenantId: args[1] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.getAuthUserByProviderUid ??
+      'getAuthUserByProviderUid',
+    (providerId: string, uid?: string, tenantId?: string) => {
+      const userUid = uid ?? Cypress.env('TEST_UID');
+      // Handle UID which is passed in
+      if (!userUid) {
+        throw new Error(
+          'uid must be passed or TEST_UID set within environment to login',
+        );
+      }
+      typedTask(cy, 'getAuthUserByProviderUid', {
+        providerId,
+        uid: userUid,
+        tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      });
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.updateAuthUser ?? 'updateAuthUser',
+    (...args: TaskNameToParams<'updateAuthUser'>) =>
+      typedTask(cy, 'updateAuthUser', {
+        uid: args[0],
+        properties: args[1],
+        tenantId: args[2] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.setAuthUserClaims ?? 'setAuthUserClaims',
+    (...args: TaskNameToParams<'setAuthUserCustomClaims'>) =>
+      typedTask(cy, 'setAuthUserCustomClaims', {
+        uid: args[0],
+        customClaims: args[1],
+        tenantId: args[2] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.deleteAuthUser ?? 'deleteAuthUser',
+    (
+      uid?: string,
+      tenantId: string | undefined = Cypress.env('TEST_TENANT_ID'),
+    ): any => {
+      const userUid = uid ?? Cypress.env('TEST_UID');
+      // Handle UID which is passed in
+      if (!userUid) {
+        throw new Error(
+          'uid must be passed or TEST_UID set within environment to login',
+        );
+      }
+
+      return typedTask(cy, 'deleteAuthUser', { uid: userUid, tenantId });
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.deleteAuthUsers ?? 'deleteAuthUsers',
+    (...args: TaskNameToParams<'deleteAuthUsers'>) =>
+      typedTask(cy, 'deleteAuthUsers', {
+        uids: args[0],
+        tenantId: args[1] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.deleteAllAuthUsers ?? 'deleteAllAuthUsers',
+    (tenantId: string | undefined = Cypress.env('TEST_TENANT_ID')): any =>
+      cy.wrap(deleteAllAuthUsers(cy, tenantId)),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.createCustomToken ?? 'createCustomToken',
+    (uid?: string, customClaims?: object, tenantId?: string) => {
+      const userUid = uid ?? Cypress.env('TEST_UID');
+      // Handle UID which is passed in
+      if (!userUid) {
+        throw new Error(
+          'uid must be passed or TEST_UID set within environment to login',
+        );
+      }
+      return typedTask(cy, 'createCustomToken', {
+        uid: userUid,
+        customClaims,
+        tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      });
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.createSessionCookie ?? 'createSessionCookie',
+    (...args: TaskNameToParams<'createSessionCookie'>) =>
+      typedTask(cy, 'createSessionCookie', {
+        idToken: args[0],
+        sessionCookieOptions: args[1],
+        tenantId: args[2] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.verifyIdToken ?? 'verifyIdToken',
+    (...args: TaskNameToParams<'verifyIdToken'>) =>
+      typedTask(cy, 'verifyIdToken', {
+        idToken: args[0],
+        checkRevoked: args[1],
+        tenantId: args[2] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.revokeRefreshTokens ?? 'revokeRefreshTokens',
+    (uid?: string, tenantId?: string) => {
+      const userUid = uid ?? Cypress.env('TEST_UID');
+      // Handle UID which is passed in
+      if (!userUid) {
+        throw new Error(
+          'uid must be passed or TEST_UID set within environment to login',
+        );
+      }
+      return typedTask(cy, 'revokeRefreshTokens', {
+        uid: userUid,
+        tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      });
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.generateEmailVerificationLink ??
+      'generateEmailVerificationLink',
+    (
+      email?: string,
+      actionCodeSettings?: auth.ActionCodeSettings,
+      tenantId?: string,
+    ) => {
+      const userEmail = email ?? Cypress.env('TEST_EMAIL');
+      // Handle email which is passed in
+      if (!userEmail) {
+        throw new Error(
+          'email must be passed or TEST_EMAIL set within environment to login',
+        );
+      }
+      return typedTask(cy, 'generateEmailVerificationLink', {
+        email: userEmail,
+        actionCodeSettings,
+        tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      });
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.generatePasswordResetLink ??
+      'generatePasswordResetLink',
+    (
+      email?: string,
+      actionCodeSettings?: auth.ActionCodeSettings,
+      tenantId?: string,
+    ) => {
+      const userEmail = email ?? Cypress.env('TEST_EMAIL');
+      // Handle email which is passed in
+      if (!userEmail) {
+        throw new Error(
+          'email must be passed or TEST_EMAIL set within environment to login',
+        );
+      }
+      return typedTask(cy, 'generatePasswordResetLink', {
+        email: userEmail,
+        actionCodeSettings,
+        tenantId: tenantId ?? Cypress.env('TEST_TENANT_ID'),
+      });
+    },
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.generateSignInWithEmailLink ??
+      'generateSignInWithEmailLink',
+    (...args: TaskNameToParams<'generateSignInWithEmailLink'>) =>
+      typedTask(cy, 'generateSignInWithEmailLink', {
+        email: args[0],
+        actionCodeSettings: args[1],
+        tenantId: args[2] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.generateVerifyAndChangeEmailLink ??
+      'generateVerifyAndChangeEmailLink',
+    (...args: TaskNameToParams<'generateVerifyAndChangeEmailLink'>) =>
+      typedTask(cy, 'generateVerifyAndChangeEmailLink', {
+        email: args[0],
+        newEmail: args[1],
+        actionCodeSettings: args[2],
+        tenantId: args[3] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.createProviderConfig ?? 'createProviderConfig',
+    (...args: TaskNameToParams<'createProviderConfig'>) =>
+      typedTask(cy, 'createProviderConfig', {
+        providerConfig: args[0],
+        tenantId: args[1] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.getProviderConfig ?? 'getProviderConfig',
+    (...args: TaskNameToParams<'getProviderConfig'>) =>
+      typedTask(cy, 'getProviderConfig', {
+        providerId: args[0],
+        tenantId: args[1] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.listProviderConfigs ?? 'listProviderConfigs',
+    (...args: TaskNameToParams<'listProviderConfigs'>) =>
+      typedTask(cy, 'listProviderConfigs', {
+        providerFilter: args[0],
+        tenantId: args[1] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.updateProviderConfig ?? 'updateProviderConfig',
+    (...args: TaskNameToParams<'updateProviderConfig'>) =>
+      typedTask(cy, 'updateProviderConfig', {
+        providerId: args[0],
+        providerConfig: args[1],
+        tenantId: args[2] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
+  );
+
+  Cypress.Commands.add(
+    options?.commandNames?.deleteProviderConfig ?? 'deleteProviderConfig',
+    (...args: TaskNameToParams<'deleteProviderConfig'>) =>
+      typedTask(cy, 'deleteProviderConfig', {
+        providerId: args[0],
+        tenantId: args[1] ?? Cypress.env('TEST_TENANT_ID'),
+      }),
   );
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -29,7 +29,7 @@ export default function pluginWithTasks(
   overrideConfig?: AppOptions,
 ): ExtendedCypressConfig {
   // Only initialize admin instance if it hasn't already been initialized
-  if (adminInstance.apps?.length === 0) {
+  if (adminInstance.apps && adminInstance.apps.length === 0) {
     initializeFirebase(adminInstance, overrideConfig);
   }
   // Parse single argument from task into arguments for task methods while

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,15 +1,14 @@
 import type { AppOptions } from 'firebase-admin';
+import type { TaskName } from './tasks';
 import extendWithFirebaseConfig, {
   ExtendedCypressConfig,
 } from './extendWithFirebaseConfig';
-import * as tasks from './tasks';
+import tasks, {
+  TaskNameToParams,
+  TaskNameToReturn,
+  taskSettingKeys,
+} from './tasks';
 import { initializeFirebase } from './firebase-utils';
-
-type TaskKey =
-  | 'callRtdb'
-  | 'callFirestore'
-  | 'createCustomToken'
-  | 'getAuthUser';
 
 /**
  * Cypress plugin which attaches tasks used by custom commands
@@ -30,35 +29,28 @@ export default function pluginWithTasks(
   overrideConfig?: AppOptions,
 ): ExtendedCypressConfig {
   // Only initialize admin instance if it hasn't already been initialized
-  if (adminInstance.apps && adminInstance.apps.length === 0) {
+  if (adminInstance.apps?.length === 0) {
     initializeFirebase(adminInstance, overrideConfig);
   }
   // Parse single argument from task into arguments for task methods while
   // also passing the admin instance
-  type tasksType = Record<TaskKey, (taskSettings: any) => Promise<any>>;
-  const tasksWithFirebase: tasksType = Object.keys(tasks).reduce(
-    (acc, taskName: string) => {
-      (acc as any)[taskName] = (taskSettings: any): any => {
-        if (taskSettings && taskSettings.uid) {
-          return (tasks as any)[taskName](
-            adminInstance,
-            taskSettings.uid,
-            taskSettings,
-          );
-        }
-        const { action, path: actionPath, options = {}, data } = taskSettings;
-        return (tasks as any)[taskName](
-          adminInstance,
-          action,
-          actionPath,
-          options,
-          data,
-        );
-      };
-      return acc;
-    },
-    {} as tasksType,
-  );
+  type tasksType = {
+    [TN in TaskName]: (
+      taskSettings: TaskNameToParams<TN>,
+    ) => TaskNameToReturn<TN>;
+  };
+  const tasksWithFirebase: tasksType = (
+    Object.keys(tasks) as TaskName[]
+  ).reduce((acc, taskName) => {
+    acc[taskName] = (taskSettings: any = {}): any => {
+      const taskArgs = taskSettingKeys[taskName].map(
+        (sk: string) => taskSettings[sk],
+      );
+      // @ts-expect-error - TS cannot know that the right amount of args are passed
+      return tasks[taskName](adminInstance, ...taskArgs);
+    };
+    return acc;
+  }, {} as tasksType);
 
   // Attach tasks to Cypress using on function
   cypressOnFunc('task', tasksWithFirebase);

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -340,12 +340,18 @@ export function createAuthUser(
   adminInstance: any,
   properties: auth.CreateRequest,
   tenantId?: string,
-): Promise<auth.UserRecord | null> {
+): Promise<
+  | auth.UserRecord
+  | 'auth/email-already-exists'
+  | 'auth/phone-number-already-exists'
+> {
   return getAuth(adminInstance, tenantId)
     .createUser(properties)
     .catch((err) => {
-      if (err.code === 'auth/email-already-exists') return null;
-      if (err.code === 'auth/phone-number-already-exists') return null;
+      if (err.code === 'auth/email-already-exists')
+        return 'auth/email-already-exists';
+      if (err.code === 'auth/phone-number-already-exists')
+        return 'auth/phone-number-already-exists';
       throw err;
     });
 }
@@ -397,8 +403,13 @@ export function getAuthUser(
   adminInstance: any,
   uid: string,
   tenantId?: string,
-): Promise<auth.UserRecord> {
-  return getAuth(adminInstance, tenantId).getUser(uid);
+): Promise<auth.UserRecord | 'auth/user-not-found'> {
+  return getAuth(adminInstance, tenantId)
+    .getUser(uid)
+    .catch((err) => {
+      if (err.code === 'auth/user-not-found') return 'auth/user-not-found';
+      throw err;
+    });
 }
 /**
  * Get Firebase Auth user based on email
@@ -411,11 +422,11 @@ export function getAuthUserByEmail(
   adminInstance: any,
   email: string,
   tenantId?: string,
-): Promise<auth.UserRecord | null> {
+): Promise<auth.UserRecord | 'auth/user-not-found'> {
   return getAuth(adminInstance, tenantId)
     .getUserByEmail(email)
     .catch((err) => {
-      if (err.code === 'auth/user-not-found') return null;
+      if (err.code === 'auth/user-not-found') return 'auth/user-not-found';
       throw err;
     });
 }
@@ -430,11 +441,11 @@ export function getAuthUserByPhoneNumber(
   adminInstance: any,
   phoneNumber: string,
   tenantId?: string,
-): Promise<auth.UserRecord | null> {
+): Promise<auth.UserRecord | 'auth/user-not-found'> {
   return getAuth(adminInstance, tenantId)
     .getUserByPhoneNumber(phoneNumber)
     .catch((err) => {
-      if (err.code === 'auth/user-not-found') return null;
+      if (err.code === 'auth/user-not-found') return 'auth/user-not-found';
       throw err;
     });
 }
@@ -451,11 +462,11 @@ export function getAuthUserByProviderUid(
   providerId: string,
   uid: string,
   tenantId?: string,
-): Promise<auth.UserRecord | null> {
+): Promise<auth.UserRecord | 'auth/user-not-found'> {
   return getAuth(adminInstance, tenantId)
     .getUserByProviderUid(providerId, uid)
     .catch((err) => {
-      if (err.code === 'auth/user-not-found') return null;
+      if (err.code === 'auth/user-not-found') return 'auth/user-not-found';
       throw err;
     });
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -507,7 +507,7 @@ export function updateAuthUser(
  * @param uid - UID of the user to edit
  * @param customClaims - The custom claims to set, null deletes the custom claims
  * @param tenantId - Optional ID of tenant used for multi-tenancy
- * @returns Promise that resolves with the current batch of downloaded users and the next page token
+ * @returns Promise that resolves with null when the operation completes
  */
 export function setAuthUserCustomClaims(
   adminInstance: any,
@@ -525,7 +525,7 @@ export function setAuthUserCustomClaims(
  * @param adminInstance - Admin SDK instance
  * @param uid - UID of the user to delete
  * @param tenantId - Optional ID of tenant used for multi-tenancy
- * @returns An empty Promise that resolves when user is deleted
+ * @returns Promise that resolves to null when user is deleted
  */
 export function deleteAuthUser(
   adminInstance: any,
@@ -782,7 +782,7 @@ export function updateProviderConfig(
  * @param adminInstance - Admin SDK instance
  * @param providerId - The provider ID
  * @param tenantId - Optional ID of tenant used for multi-tenancy
- * @returns Promise which resolves when the operation completes
+ * @returns Promise which resolves to null when the operation completes
  */
 export function deleteProviderConfig(
   adminInstance: any,

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -337,7 +337,7 @@ export async function callFirestore(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with a UserRecord
  */
-export function createAuthUser(
+export function authCreateUser(
   adminInstance: any,
   properties: auth.CreateRequest,
   tenantId?: string,
@@ -364,7 +364,7 @@ export function createAuthUser(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise that resolves when the operation completes with the result of the import
  */
-export function importAuthUsers(
+export function authImportUsers(
   adminInstance: any,
   usersImport: auth.UserImportRecord[],
   importOptions?: auth.UserImportOptions,
@@ -384,7 +384,7 @@ export function importAuthUsers(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise that resolves with the current batch of downloaded users and the next page token
  */
-export function listAuthUsers(
+export function authListUsers(
   adminInstance: any,
   maxResults?: number,
   pageToken?: string,
@@ -400,7 +400,7 @@ export function listAuthUsers(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with a UserRecord
  */
-export function getAuthUser(
+export function authGetUser(
   adminInstance: any,
   uid: string,
   tenantId?: string,
@@ -419,7 +419,7 @@ export function getAuthUser(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with a UserRecord
  */
-export function getAuthUserByEmail(
+export function authGetUserByEmail(
   adminInstance: any,
   email: string,
   tenantId?: string,
@@ -438,7 +438,7 @@ export function getAuthUserByEmail(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with a UserRecord
  */
-export function getAuthUserByPhoneNumber(
+export function authGetUserByPhoneNumber(
   adminInstance: any,
   phoneNumber: string,
   tenantId?: string,
@@ -458,7 +458,7 @@ export function getAuthUserByPhoneNumber(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with a UserRecord
  */
-export function getAuthUserByProviderUid(
+export function authGetUserByProviderUid(
   adminInstance: any,
   providerId: string,
   uid: string,
@@ -478,7 +478,7 @@ export function getAuthUserByProviderUid(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with a GetUsersResult object
  */
-export function getAuthUsers(
+export function authGetUsers(
   adminInstance: any,
   identifiers: auth.UserIdentifier[],
   tenantId?: string,
@@ -494,7 +494,7 @@ export function getAuthUsers(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise that resolves with a UserRecord
  */
-export function updateAuthUser(
+export function authUpdateUser(
   adminInstance: any,
   uid: string,
   properties: auth.UpdateRequest,
@@ -510,7 +510,7 @@ export function updateAuthUser(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise that resolves with null when the operation completes
  */
-export function setAuthUserCustomClaims(
+export function authSetCustomUserClaims(
   adminInstance: any,
   uid: string,
   customClaims: object | null,
@@ -528,7 +528,7 @@ export function setAuthUserCustomClaims(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise that resolves to null when user is deleted
  */
-export function deleteAuthUser(
+export function authDeleteUser(
   adminInstance: any,
   uid: string,
   tenantId?: string,
@@ -544,7 +544,7 @@ export function deleteAuthUser(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves to a DeleteUsersResult object
  */
-export function deleteAuthUsers(
+export function authDeleteUsers(
   adminInstance: any,
   uids: string[],
   tenantId?: string,
@@ -560,7 +560,7 @@ export function deleteAuthUsers(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with a custom Firebase Auth token
  */
-export function createCustomToken(
+export function authCreateCustomToken(
   adminInstance: any,
   uid: string,
   customClaims?: object,
@@ -586,7 +586,7 @@ export function createCustomToken(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with a session cookie
  */
-export function createSessionCookie(
+export function authCreateSessionCookie(
   adminInstance: any,
   idToken: string,
   sessionCookieOptions: auth.SessionCookieOptions,
@@ -606,7 +606,7 @@ export function createSessionCookie(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with a decoded ID token
  */
-export function verifyIdToken(
+export function authVerifyIdToken(
   adminInstance: any,
   idToken: string,
   checkRevoked?: boolean,
@@ -622,7 +622,7 @@ export function verifyIdToken(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves when the operation completes
  */
-export function revokeRefreshTokens(
+export function authRevokeRefreshTokens(
   adminInstance: any,
   uid: string,
   tenantId?: string,
@@ -638,7 +638,7 @@ export function revokeRefreshTokens(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with the email verification link
  */
-export function generateEmailVerificationLink(
+export function authGenerateEmailVerificationLink(
   adminInstance: any,
   email: string,
   actionCodeSettings?: auth.ActionCodeSettings,
@@ -658,7 +658,7 @@ export function generateEmailVerificationLink(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with the password reset link
  */
-export function generatePasswordResetLink(
+export function authGeneratePasswordResetLink(
   adminInstance: any,
   email: string,
   actionCodeSettings?: auth.ActionCodeSettings,
@@ -678,7 +678,7 @@ export function generatePasswordResetLink(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with the sign-in with email link
  */
-export function generateSignInWithEmailLink(
+export function authGenerateSignInWithEmailLink(
   adminInstance: any,
   email: string,
   actionCodeSettings: auth.ActionCodeSettings,
@@ -699,7 +699,7 @@ export function generateSignInWithEmailLink(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with the email verification link
  */
-export function generateVerifyAndChangeEmailLink(
+export function authGenerateVerifyAndChangeEmailLink(
   adminInstance: any,
   email: string,
   newEmail: string,
@@ -720,7 +720,7 @@ export function generateVerifyAndChangeEmailLink(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with the provider configuration
  */
-export function createProviderConfig(
+export function authCreateProviderConfig(
   adminInstance: any,
   providerConfig: auth.AuthProviderConfig,
   tenantId?: string,
@@ -735,7 +735,7 @@ export function createProviderConfig(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with the provider configuration
  */
-export function getProviderConfig(
+export function authGetProviderConfig(
   adminInstance: any,
   providerId: string,
   tenantId?: string,
@@ -750,7 +750,7 @@ export function getProviderConfig(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with the provider configurations
  */
-export function listProviderConfigs(
+export function authListProviderConfigs(
   adminInstance: any,
   providerFilter: auth.AuthProviderConfigFilter,
   tenantId?: string,
@@ -766,7 +766,7 @@ export function listProviderConfigs(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves with the provider configuration
  */
-export function updateProviderConfig(
+export function authUpdateProviderConfig(
   adminInstance: any,
   providerId: string,
   providerConfig: auth.AuthProviderConfig,
@@ -785,7 +785,7 @@ export function updateProviderConfig(
  * @param tenantId - Optional ID of tenant used for multi-tenancy
  * @returns Promise which resolves to null when the operation completes
  */
-export function deleteProviderConfig(
+export function authDeleteProviderConfig(
   adminInstance: any,
   providerId: string,
   tenantId?: string,
@@ -801,31 +801,31 @@ export function deleteProviderConfig(
 const tasks = {
   callRtdb,
   callFirestore,
-  createAuthUser,
-  importAuthUsers,
-  listAuthUsers,
-  getAuthUser,
-  getAuthUserByEmail,
-  getAuthUserByPhoneNumber,
-  getAuthUserByProviderUid,
-  getAuthUsers,
-  updateAuthUser,
-  setAuthUserCustomClaims,
-  deleteAuthUser,
-  deleteAuthUsers,
-  createCustomToken,
-  createSessionCookie,
-  verifyIdToken,
-  revokeRefreshTokens,
-  generateEmailVerificationLink,
-  generatePasswordResetLink,
-  generateSignInWithEmailLink,
-  generateVerifyAndChangeEmailLink,
-  createProviderConfig,
-  getProviderConfig,
-  listProviderConfigs,
-  updateProviderConfig,
-  deleteProviderConfig,
+  authCreateUser,
+  authImportUsers,
+  authListUsers,
+  authGetUser,
+  authGetUserByEmail,
+  authGetUserByPhoneNumber,
+  authGetUserByProviderUid,
+  authGetUsers,
+  authUpdateUser,
+  authSetCustomUserClaims,
+  authDeleteUser,
+  authDeleteUsers,
+  authCreateCustomToken,
+  authCreateSessionCookie,
+  authVerifyIdToken,
+  authRevokeRefreshTokens,
+  authGenerateEmailVerificationLink,
+  authGeneratePasswordResetLink,
+  authGenerateSignInWithEmailLink,
+  authGenerateVerifyAndChangeEmailLink,
+  authCreateProviderConfig,
+  authGetProviderConfig,
+  authListProviderConfigs,
+  authUpdateProviderConfig,
+  authDeleteProviderConfig,
 };
 /**
  * Type of all the names of tasks created by the plugin
@@ -855,36 +855,40 @@ export type TaskNameToReturn<TN extends TaskName> = ReturnType<
 export const taskSettingKeys = {
   callRtdb: ['action', 'path', 'options', 'data'],
   callFirestore: ['action', 'path', 'options', 'data'],
-  createAuthUser: ['properties', 'tenantId'],
-  importAuthUsers: ['usersImport', 'importOptions', 'tenantId'],
-  listAuthUsers: ['maxResults', 'pageToken', 'tenantId'],
-  getAuthUser: ['uid', 'tenantId'],
-  getAuthUserByEmail: ['email', 'tenantId'],
-  getAuthUserByPhoneNumber: ['phoneNumber', 'tenantId'],
-  getAuthUserByProviderUid: ['providerId', 'uid', 'tenantId'],
-  getAuthUsers: ['identifiers', 'tenantId'],
-  updateAuthUser: ['uid', 'properties', 'tenantId'],
-  setAuthUserCustomClaims: ['uid', 'customClaims', 'tenantId'],
-  deleteAuthUser: ['uid', 'tenantId'],
-  deleteAuthUsers: ['uids', 'tenantId'],
-  createCustomToken: ['uid', 'customClaims', 'tenantId'],
-  createSessionCookie: ['idToken', 'sessionCookieOptions', 'tenantId'],
-  verifyIdToken: ['idToken', 'checkRevoked', 'tenantId'],
-  revokeRefreshTokens: ['uid', 'tenantId'],
-  generateEmailVerificationLink: ['email', 'actionCodeSettings', 'tenantId'],
-  generatePasswordResetLink: ['email', 'actionCodeSettings', 'tenantId'],
-  generateSignInWithEmailLink: ['email', 'actionCodeSettings', 'tenantId'],
-  generateVerifyAndChangeEmailLink: [
+  authCreateUser: ['properties', 'tenantId'],
+  authImportUsers: ['usersImport', 'importOptions', 'tenantId'],
+  authListUsers: ['maxResults', 'pageToken', 'tenantId'],
+  authGetUser: ['uid', 'tenantId'],
+  authGetUserByEmail: ['email', 'tenantId'],
+  authGetUserByPhoneNumber: ['phoneNumber', 'tenantId'],
+  authGetUserByProviderUid: ['providerId', 'uid', 'tenantId'],
+  authGetUsers: ['identifiers', 'tenantId'],
+  authUpdateUser: ['uid', 'properties', 'tenantId'],
+  authSetCustomUserClaims: ['uid', 'customClaims', 'tenantId'],
+  authDeleteUser: ['uid', 'tenantId'],
+  authDeleteUsers: ['uids', 'tenantId'],
+  authCreateCustomToken: ['uid', 'customClaims', 'tenantId'],
+  authCreateSessionCookie: ['idToken', 'sessionCookieOptions', 'tenantId'],
+  authVerifyIdToken: ['idToken', 'checkRevoked', 'tenantId'],
+  authRevokeRefreshTokens: ['uid', 'tenantId'],
+  authGenerateEmailVerificationLink: [
+    'email',
+    'actionCodeSettings',
+    'tenantId',
+  ],
+  authGeneratePasswordResetLink: ['email', 'actionCodeSettings', 'tenantId'],
+  authGenerateSignInWithEmailLink: ['email', 'actionCodeSettings', 'tenantId'],
+  authGenerateVerifyAndChangeEmailLink: [
     'email',
     'newEmail',
     'actionCodeSettings',
     'tenantId',
   ],
-  createProviderConfig: ['providerConfig', 'tenantId'],
-  getProviderConfig: ['providerId', 'tenantId'],
-  listProviderConfigs: ['providerFilter', 'tenantId'],
-  updateProviderConfig: ['providerId', 'providerConfig', 'tenantId'],
-  deleteProviderConfig: ['providerId', 'tenantId'],
+  authCreateProviderConfig: ['providerConfig', 'tenantId'],
+  authGetProviderConfig: ['providerId', 'tenantId'],
+  authListProviderConfigs: ['providerFilter', 'tenantId'],
+  authUpdateProviderConfig: ['providerId', 'providerConfig', 'tenantId'],
+  authDeleteProviderConfig: ['providerId', 'tenantId'],
 } as const satisfies { [TN in TaskName]: readonly string[] };
 
 /**

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -5,6 +5,7 @@ import {
   RTDBAction,
   CallRtdbOptions,
   CallFirestoreOptions,
+  AttachCustomCommandParams,
 } from './attachCustomCommands';
 import {
   slashPathToFirestoreRef,
@@ -34,7 +35,7 @@ function optionsToRtdbRef(
     'limitToFirst',
     'limitToLast',
   ].forEach((optionName: string) => {
-    if (options && (options as any)[optionName]) {
+    if ((options as any)?.[optionName]) {
       const args = (options as any)[optionName];
       // Spread arg arrays (such as startAfter and endBefore)
       if (Array.isArray(args)) {
@@ -76,14 +77,14 @@ export function convertValueToTimestampOrGeoPointIfPossible(
 ): firestore.FieldValue {
   /* eslint-disable no-underscore-dangle */
   if (
-    (dataVal && dataVal._methodName) === 'serverTimestamp' ||
-    (dataVal && dataVal._methodName) === 'FieldValue.serverTimestamp' // v8 and earlier
+    dataVal?._methodName === 'serverTimestamp' ||
+    dataVal?._methodName === 'FieldValue.serverTimestamp' // v8 and earlier
   ) {
     return firestoreStatics.FieldValue.serverTimestamp();
   }
   if (
-    (dataVal && dataVal._methodName) === 'deleteField' ||
-    (dataVal && dataVal._methodName) === 'FieldValue.delete' // v8 and earlier
+    dataVal?._methodName === 'deleteField' ||
+    dataVal?._methodName === 'FieldValue.delete' // v8 and earlier
   ) {
     return firestoreStatics.FieldValue.delete();
   }
@@ -202,7 +203,7 @@ export async function callRtdb(
     };
     type RTDBMethod = 'push' | 'remove' | 'set' | 'update' | 'get';
     const cleanedActionName: RTDBMethod =
-      (actionNameMap as any)[action] || action;
+      (actionNameMap as any)[action] ?? action;
     await dbRef[cleanedActionName](data);
     // Prevents Cypress error with message:
     // "You must return a promise, a value, or null to indicate that the task was handled."
@@ -256,7 +257,7 @@ export async function callFirestore(
       }
       // Falling back to null in the case of falsey value prevents Cypress error with message:
       // "You must return a promise, a value, or null to indicate that the task was handled."
-      return (typeof (snap && snap.data) === 'function' && snap.data()) || null;
+      return (typeof snap?.data === 'function' && snap.data()) || null;
     }
 
     if (action === 'delete') {
@@ -294,8 +295,7 @@ export async function callFirestore(
       data,
       // Use static option if passed (tests), otherwise fallback to statics on adminInstance
       // Tests do not have statics since they are using @firebase/testing
-      (options && options.statics) ||
-        (adminInstance.firestore as typeof firestore),
+      options?.statics ?? (adminInstance.firestore as typeof firestore),
     );
 
     if (action === 'set') {
@@ -304,9 +304,9 @@ export async function callFirestore(
         .doc(actionPath)
         .set(
           dataToSet,
-          options && options.merge
+          options?.merge
             ? ({
-                merge: options && options.merge,
+                merge: options?.merge,
               } as FirebaseFirestore.SetOptions)
             : (undefined as any),
         );
@@ -329,37 +329,69 @@ export async function callFirestore(
     throw err;
   }
 }
+/**
+ * Create a Firebase Auth user
+ * @param adminInstance - Admin SDK instance
+ * @param properties - The properties to set on the new user record to be created
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with a UserRecord
+ */
+export function createAuthUser(
+  adminInstance: any,
+  properties: auth.CreateRequest,
+  tenantId?: string,
+): Promise<auth.UserRecord | null> {
+  return getAuth(adminInstance, tenantId)
+    .createUser(properties)
+    .catch((err) => {
+      if (err.code === 'auth/email-already-exists') return null;
+      if (err.code === 'auth/phone-number-already-exists') return null;
+      throw err;
+    });
+}
+/**
+ * Import list of Firebase Auth users
+ * @param adminInstance - Admin SDK instance
+ * @param usersImport - The list of user records to import to Firebase Auth
+ * @param importOptions - Optional options for the user import
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise that resolves when the operation completes with the result of the import
+ */
+export function importAuthUsers(
+  adminInstance: any,
+  usersImport: auth.UserImportRecord[],
+  importOptions?: auth.UserImportOptions,
+  tenantId?: string,
+): Promise<auth.UserImportResult> {
+  return getAuth(adminInstance, tenantId).importUsers(
+    usersImport,
+    importOptions,
+  );
+}
 
 /**
- * Create a custom token
+ * List Firebase Auth users
  * @param adminInstance - Admin SDK instance
- * @param uid - UID of user for which the custom token will be generated
- * @param settings - Settings object
- * @returns Promise which resolves with a custom Firebase Auth token
+ * @param maxResults - The page size, 1000 if undefined
+ * @param pageToken - The next page token
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise that resolves with the current batch of downloaded users and the next page token
  */
-export function createCustomToken(
+export function listAuthUsers(
   adminInstance: any,
-  uid: string,
-  settings?: any,
-): Promise<string> {
-  // Use custom claims or default to { isTesting: true }
-  const customClaims = (settings && settings.customClaims) || {
-    isTesting: true,
-  };
-
-  // Create auth token
-  return getAuth(adminInstance, settings.tenantId).createCustomToken(
-    uid,
-    customClaims,
-  );
+  maxResults?: number,
+  pageToken?: string,
+  tenantId?: string,
+): Promise<auth.ListUsersResult> {
+  return getAuth(adminInstance, tenantId).listUsers(maxResults, pageToken);
 }
 
 /**
  * Get Firebase Auth user based on UID
  * @param adminInstance - Admin SDK instance
- * @param uid - UID of user for which the custom token will be generated
+ * @param uid - UID of the user whose data to fetch
  * @param tenantId - Optional ID of tenant used for multi-tenancy
- * @returns Promise which resolves with a custom Firebase Auth token
+ * @returns Promise which resolves with a UserRecord
  */
 export function getAuthUser(
   adminInstance: any,
@@ -368,3 +400,521 @@ export function getAuthUser(
 ): Promise<auth.UserRecord> {
   return getAuth(adminInstance, tenantId).getUser(uid);
 }
+/**
+ * Get Firebase Auth user based on email
+ * @param adminInstance - Admin SDK instance
+ * @param email - Email of the user whose data to fetch
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with a UserRecord
+ */
+export function getAuthUserByEmail(
+  adminInstance: any,
+  email: string,
+  tenantId?: string,
+): Promise<auth.UserRecord | null> {
+  return getAuth(adminInstance, tenantId)
+    .getUserByEmail(email)
+    .catch((err) => {
+      if (err.code === 'auth/user-not-found') return null;
+      throw err;
+    });
+}
+/**
+ * Get Firebase Auth user based on phone number
+ * @param adminInstance - Admin SDK instance
+ * @param phoneNumber - Phone number of the user whose data to fetch
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with a UserRecord
+ */
+export function getAuthUserByPhoneNumber(
+  adminInstance: any,
+  phoneNumber: string,
+  tenantId?: string,
+): Promise<auth.UserRecord | null> {
+  return getAuth(adminInstance, tenantId)
+    .getUserByPhoneNumber(phoneNumber)
+    .catch((err) => {
+      if (err.code === 'auth/user-not-found') return null;
+      throw err;
+    });
+}
+/**
+ * Get Firebase Auth user based on phone number
+ * @param adminInstance - Admin SDK instance
+ * @param providerId - The Provider ID
+ * @param uid - The user identifier for the given provider
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with a UserRecord
+ */
+export function getAuthUserByProviderUid(
+  adminInstance: any,
+  providerId: string,
+  uid: string,
+  tenantId?: string,
+): Promise<auth.UserRecord | null> {
+  return getAuth(adminInstance, tenantId)
+    .getUserByProviderUid(providerId, uid)
+    .catch((err) => {
+      if (err.code === 'auth/user-not-found') return null;
+      throw err;
+    });
+}
+/**
+ * Get Firebase Auth users based on identifiers
+ * @param adminInstance - Admin SDK instance
+ * @param identifiers - The identifiers used to indicate which user records should be returned.
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with a GetUsersResult object
+ */
+export function getAuthUsers(
+  adminInstance: any,
+  identifiers: auth.UserIdentifier[],
+  tenantId?: string,
+): Promise<auth.GetUsersResult> {
+  return getAuth(adminInstance, tenantId).getUsers(identifiers);
+}
+
+/**
+ * Update an existing Firebase Auth user
+ * @param adminInstance - Admin SDK instance
+ * @param uid - UID of the user to edit
+ * @param properties - The properties to update on the user
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise that resolves with a UserRecord
+ */
+export function updateAuthUser(
+  adminInstance: any,
+  uid: string,
+  properties: auth.UpdateRequest,
+  tenantId?: string,
+): Promise<auth.UserRecord> {
+  return getAuth(adminInstance, tenantId).updateUser(uid, properties);
+}
+/**
+ * Delete multiple Firebase Auth users
+ * @param adminInstance - Admin SDK instance
+ * @param uid - UID of the user to edit
+ * @param customClaims - The custom claims to set, null deletes the custom claims
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise that resolves with the current batch of downloaded users and the next page token
+ */
+export function setAuthUserCustomClaims(
+  adminInstance: any,
+  uid: string,
+  customClaims: object | null,
+  tenantId?: string,
+): Promise<null> {
+  return getAuth(adminInstance, tenantId)
+    .setCustomUserClaims(uid, customClaims)
+    .then(() => null);
+}
+
+/**
+ * Delete a Firebase Auth user
+ * @param adminInstance - Admin SDK instance
+ * @param uid - UID of the user to delete
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns An empty Promise that resolves when user is deleted
+ */
+export function deleteAuthUser(
+  adminInstance: any,
+  uid: string,
+  tenantId?: string,
+): Promise<null> {
+  return getAuth(adminInstance, tenantId)
+    .deleteUser(uid)
+    .then(() => null);
+}
+/**
+ * Delete multiple Firebase Auth users
+ * @param adminInstance - Admin SDK instance
+ * @param uids - Array of UIDs of the users to delete
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves to a DeleteUsersResult object
+ */
+export function deleteAuthUsers(
+  adminInstance: any,
+  uids: string[],
+  tenantId?: string,
+): Promise<auth.DeleteUsersResult> {
+  return getAuth(adminInstance, tenantId).deleteUsers(uids);
+}
+
+/**
+ * Create a custom token
+ * @param adminInstance - Admin SDK instance
+ * @param uid - UID of user for which the custom token will be generated
+ * @param customClaims - Optional custom claims to include in the token
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with a custom Firebase Auth token
+ */
+export function createCustomToken(
+  adminInstance: any,
+  uid: string,
+  customClaims?: object,
+  tenantId?: string,
+): Promise<string> {
+  // Use custom claims or default to { isTesting: true }
+  const userCustomClaims = customClaims ?? {
+    isTesting: true,
+  };
+
+  // Create auth token
+  return getAuth(adminInstance, tenantId).createCustomToken(
+    uid,
+    userCustomClaims,
+  );
+}
+
+/**
+ * Create a session cookie
+ * @param adminInstance - Admin SDK instance
+ * @param idToken - Firebase ID token
+ * @param sessionCookieOptions - Session cookie options
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with a session cookie
+ */
+export function createSessionCookie(
+  adminInstance: any,
+  idToken: string,
+  sessionCookieOptions: auth.SessionCookieOptions,
+  tenantId?: string,
+): Promise<string> {
+  return getAuth(adminInstance, tenantId).createSessionCookie(
+    idToken,
+    sessionCookieOptions,
+  );
+}
+
+/**
+ * Verify a Firebase ID token
+ * @param adminInstance - Admin SDK instance
+ * @param idToken - Firebase ID token
+ * @param checkRevoked - Whether to check if the token is revoked
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with a decoded ID token
+ */
+export function verifyIdToken(
+  adminInstance: any,
+  idToken: string,
+  checkRevoked?: boolean,
+  tenantId?: string,
+): Promise<auth.DecodedIdToken> {
+  return getAuth(adminInstance, tenantId).verifyIdToken(idToken, checkRevoked);
+}
+
+/**
+ * Revoke all refresh tokens for a user
+ * @param adminInstance - Admin SDK instance
+ * @param uid - UID of the user for which to revoke tokens
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves when the operation completes
+ */
+export function revokeRefreshTokens(
+  adminInstance: any,
+  uid: string,
+  tenantId?: string,
+): Promise<void> {
+  return getAuth(adminInstance, tenantId).revokeRefreshTokens(uid);
+}
+
+/**
+ * Generate an email verification link
+ * @param adminInstance - Admin SDK instance
+ * @param email - Email of the user
+ * @param actionCodeSettings - Action code settings
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with the email verification link
+ */
+export function generateEmailVerificationLink(
+  adminInstance: any,
+  email: string,
+  actionCodeSettings?: auth.ActionCodeSettings,
+  tenantId?: string,
+): Promise<string> {
+  return getAuth(adminInstance, tenantId).generateEmailVerificationLink(
+    email,
+    actionCodeSettings,
+  );
+}
+
+/**
+ * Generate a password reset link
+ * @param adminInstance - Admin SDK instance
+ * @param email - Email of the user
+ * @param actionCodeSettings - Action code settings
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with the password reset link
+ */
+export function generatePasswordResetLink(
+  adminInstance: any,
+  email: string,
+  actionCodeSettings?: auth.ActionCodeSettings,
+  tenantId?: string,
+): Promise<string> {
+  return getAuth(adminInstance, tenantId).generatePasswordResetLink(
+    email,
+    actionCodeSettings,
+  );
+}
+
+/**
+ * Generate a sign-in with email link
+ * @param adminInstance - Admin SDK instance
+ * @param email - Email of the user
+ * @param actionCodeSettings - Action code settings
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with the sign-in with email link
+ */
+export function generateSignInWithEmailLink(
+  adminInstance: any,
+  email: string,
+  actionCodeSettings: auth.ActionCodeSettings,
+  tenantId?: string,
+): Promise<string> {
+  return getAuth(adminInstance, tenantId).generateSignInWithEmailLink(
+    email,
+    actionCodeSettings,
+  );
+}
+
+/**
+ * Generate a link for email verification and email change
+ * @param adminInstance - Admin SDK instance
+ * @param email - Email of the user
+ * @param newEmail - New email of the user
+ * @param actionCodeSettings - Action code settings
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with the email verification link
+ */
+export function generateVerifyAndChangeEmailLink(
+  adminInstance: any,
+  email: string,
+  newEmail: string,
+  actionCodeSettings?: auth.ActionCodeSettings,
+  tenantId?: string,
+): Promise<string> {
+  return getAuth(adminInstance, tenantId).generateVerifyAndChangeEmailLink(
+    email,
+    newEmail,
+    actionCodeSettings,
+  );
+}
+
+/**
+ * Create a provider configuration
+ * @param adminInstance - Admin SDK instance
+ * @param providerConfig - The provider configuration
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with the provider configuration
+ */
+export function createProviderConfig(
+  adminInstance: any,
+  providerConfig: auth.AuthProviderConfig,
+  tenantId?: string,
+): Promise<auth.AuthProviderConfig> {
+  return getAuth(adminInstance, tenantId).createProviderConfig(providerConfig);
+}
+
+/**
+ * Get a provider configuration
+ * @param adminInstance - Admin SDK instance
+ * @param providerId - The provider ID
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with the provider configuration
+ */
+export function getProviderConfig(
+  adminInstance: any,
+  providerId: string,
+  tenantId?: string,
+): Promise<auth.AuthProviderConfig> {
+  return getAuth(adminInstance, tenantId).getProviderConfig(providerId);
+}
+
+/**
+ * List provider configurations
+ * @param adminInstance - Admin SDK instance
+ * @param providerFilter - The provider filter
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with the provider configurations
+ */
+export function listProviderConfigs(
+  adminInstance: any,
+  providerFilter: auth.AuthProviderConfigFilter,
+  tenantId?: string,
+): Promise<auth.ListProviderConfigResults> {
+  return getAuth(adminInstance, tenantId).listProviderConfigs(providerFilter);
+}
+
+/**
+ * Update a provider configuration
+ * @param adminInstance - Admin SDK instance
+ * @param providerId - The provider ID
+ * @param providerConfig - The provider configuration
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves with the provider configuration
+ */
+export function updateProviderConfig(
+  adminInstance: any,
+  providerId: string,
+  providerConfig: auth.AuthProviderConfig,
+  tenantId?: string,
+): Promise<auth.AuthProviderConfig> {
+  return getAuth(adminInstance, tenantId).updateProviderConfig(
+    providerId,
+    providerConfig,
+  );
+}
+
+/**
+ * Delete a provider configuration
+ * @param adminInstance - Admin SDK instance
+ * @param providerId - The provider ID
+ * @param tenantId - Optional ID of tenant used for multi-tenancy
+ * @returns Promise which resolves when the operation completes
+ */
+export function deleteProviderConfig(
+  adminInstance: any,
+  providerId: string,
+  tenantId?: string,
+): Promise<null> {
+  return getAuth(adminInstance, tenantId)
+    .deleteProviderConfig(providerId)
+    .then(() => null);
+}
+
+/**
+ * Object containing all tasks created by the plugin
+ */
+const tasks = {
+  callRtdb,
+  callFirestore,
+  createAuthUser,
+  importAuthUsers,
+  listAuthUsers,
+  getAuthUser,
+  getAuthUserByEmail,
+  getAuthUserByPhoneNumber,
+  getAuthUserByProviderUid,
+  getAuthUsers,
+  updateAuthUser,
+  setAuthUserCustomClaims,
+  deleteAuthUser,
+  deleteAuthUsers,
+  createCustomToken,
+  createSessionCookie,
+  verifyIdToken,
+  revokeRefreshTokens,
+  generateEmailVerificationLink,
+  generatePasswordResetLink,
+  generateSignInWithEmailLink,
+  generateVerifyAndChangeEmailLink,
+  createProviderConfig,
+  getProviderConfig,
+  listProviderConfigs,
+  updateProviderConfig,
+  deleteProviderConfig,
+};
+/**
+ * Type of all the names of tasks created by the plugin
+ */
+export type TaskName = keyof typeof tasks;
+
+/**
+ * Given a tuple, return a tuple with the first element dropped
+ */
+type DropFirstElem<T extends any[]> = T extends [any, ...infer U] ? U : never;
+/**
+ * Given a task name, return the parameters of the task
+ */
+export type TaskNameToParams<TN extends TaskName> = DropFirstElem<
+  Parameters<(typeof tasks)[TN]>
+>;
+/**
+ * Given a task name, return the return type of the task
+ */
+export type TaskNameToReturn<TN extends TaskName> = ReturnType<
+  (typeof tasks)[TN]
+>;
+
+/**
+ * Object mapping task names to their settings keys
+ */
+export const taskSettingKeys = {
+  callRtdb: ['action', 'path', 'options', 'data'],
+  callFirestore: ['action', 'path', 'options', 'data'],
+  createAuthUser: ['properties', 'tenantId'],
+  importAuthUsers: ['usersImport', 'importOptions', 'tenantId'],
+  listAuthUsers: ['maxResults', 'pageToken', 'tenantId'],
+  getAuthUser: ['uid', 'tenantId'],
+  getAuthUserByEmail: ['email', 'tenantId'],
+  getAuthUserByPhoneNumber: ['phoneNumber', 'tenantId'],
+  getAuthUserByProviderUid: ['providerId', 'uid', 'tenantId'],
+  getAuthUsers: ['identifiers', 'tenantId'],
+  updateAuthUser: ['uid', 'properties', 'tenantId'],
+  setAuthUserCustomClaims: ['uid', 'customClaims', 'tenantId'],
+  deleteAuthUser: ['uid', 'tenantId'],
+  deleteAuthUsers: ['uids', 'tenantId'],
+  createCustomToken: ['uid', 'customClaims', 'tenantId'],
+  createSessionCookie: ['idToken', 'sessionCookieOptions', 'tenantId'],
+  verifyIdToken: ['idToken', 'checkRevoked', 'tenantId'],
+  revokeRefreshTokens: ['uid', 'tenantId'],
+  generateEmailVerificationLink: ['email', 'actionCodeSettings', 'tenantId'],
+  generatePasswordResetLink: ['email', 'actionCodeSettings', 'tenantId'],
+  generateSignInWithEmailLink: ['email', 'actionCodeSettings', 'tenantId'],
+  generateVerifyAndChangeEmailLink: [
+    'email',
+    'newEmail',
+    'actionCodeSettings',
+    'tenantId',
+  ],
+  createProviderConfig: ['providerConfig', 'tenantId'],
+  getProviderConfig: ['providerId', 'tenantId'],
+  listProviderConfigs: ['providerFilter', 'tenantId'],
+  updateProviderConfig: ['providerId', 'providerConfig', 'tenantId'],
+  deleteProviderConfig: ['providerId', 'tenantId'],
+} as const satisfies { [TN in TaskName]: readonly string[] };
+
+/**
+ * Given a task name, return the settings for the task
+ */
+type TaskNameToSettings<TN extends TaskName> = [
+  (typeof taskSettingKeys)[TN],
+  TaskNameToParams<TN>,
+  // make shorthands for the settings keys and params of the task
+] extends [infer TNK, infer TNP]
+  ? {
+      // get only the indexes and not other array properties
+      [I in Extract<
+        keyof TNK,
+        `${number}`
+        // only those keys that do not have undefined as a value and thus are required
+        // @ts-expect-error - TS cannot know that the amount of params coincides with the amount of taskSettingKeys
+      > as undefined extends TNP[I] ? never : TNK[I]]: TNP[I];
+    } & {
+      // get only the indexes and not other array properties
+      [I in Extract<
+        keyof TNK,
+        `${number}`
+        // only those keys that do have undefined as a value and thus are optional
+        // @ts-expect-error - TS cannot know that the amount of params coincides with the amount of taskSettingKeys
+      > as undefined extends TNP[I] ? TNK[I] : never]?: TNP[I];
+    }
+  : never;
+
+/**
+ * A drop-in replacement for cy.task that provides type safe tasks
+ * @param cy - The Cypress object
+ * @param taskName - The name of the task
+ * @param taskSettings - The settings for the task
+ * @returns - A Cypress Chainable with the return type of the task
+ */
+export function typedTask<TN extends TaskName>(
+  cy: AttachCustomCommandParams['cy'],
+  taskName: TN,
+  taskSettings: TaskNameToSettings<TN>,
+): Cypress.Chainable<Awaited<TaskNameToReturn<TN>>> {
+  return cy.task(taskName, taskSettings);
+}
+
+export default tasks;

--- a/test/unit/attachCustomCommands.spec.ts
+++ b/test/unit/attachCustomCommands.spec.ts
@@ -286,7 +286,10 @@ describe('attachCustomCommands', () => {
     it('calls task with uid', async () => {
       const uid = 'TESTING_USER_UID';
       await loadedCustomCommands.getAuthUser(uid);
-      expect(taskSpy).to.have.been.calledWith('getAuthUser', uid);
+      expect(taskSpy).to.have.been.calledWith('getAuthUser', {
+        uid,
+        tenantId: false,
+      });
     });
   });
 

--- a/test/unit/attachCustomCommands.spec.ts
+++ b/test/unit/attachCustomCommands.spec.ts
@@ -25,6 +25,41 @@ const firebase = {
   firestore: { Timestamp: { now: () => 'TIMESTAMP' } },
 };
 
+const allCommandNames = [
+  'callRtdb',
+  'callFirestore',
+  'authCreateUser',
+  'createUserWithClaims',
+  'authImportUsers',
+  'authListUsers',
+  'login',
+  'loginWithEmailAndPassword',
+  'logout',
+  'authGetUser',
+  'authGetUserByEmail',
+  'authGetUserByPhoneNumber',
+  'authGetUserByProviderUid',
+  'authGetUsers',
+  'authUpdateUser',
+  'authSetCustomUserClaims',
+  'authDeleteUser',
+  'authDeleteUsers',
+  'deleteAllAuthUsers',
+  'authCreateCustomToken',
+  'authCreateSessionCookie',
+  'authVerifyIdToken',
+  'authRevokeRefreshTokens',
+  'authGenerateEmailVerificationLink',
+  'authGeneratePasswordResetLink',
+  'authGenerateSignInWithEmailLink',
+  'authGenerateVerifyAndChangeEmailLink',
+  'authCreateProviderConfig',
+  'authGetProviderConfig',
+  'authListProviderConfigs',
+  'authUpdateProviderConfig',
+  'authDeleteProviderConfig',
+];
+
 describe('attachCustomCommands', () => {
   beforeEach(() => {
     currentUser = {};
@@ -44,7 +79,7 @@ describe('attachCustomCommands', () => {
   });
 
   describe('cy.login', () => {
-    it('Is attached as a custom command', () => {
+    it('is attached as a custom command', () => {
       expect(addSpy).to.have.been.calledWith('login');
     });
 
@@ -71,7 +106,7 @@ describe('attachCustomCommands', () => {
       expect(returnVal).to.be.undefined;
     });
 
-    it('calls task with uid and custom claims', async () => {
+    it('calls task with parameters and custom claims', async () => {
       await loadedCustomCommands.login('123ABC');
       expect(taskSpy).to.have.been.calledOnce;
       expect(signInWithCustomToken).to.have.been.calledOnce;
@@ -82,7 +117,7 @@ describe('attachCustomCommands', () => {
       attachCustomCommands({ cy, Cypress, firebase });
       envStub.withArgs('TEST_UID').returns('foo');
       await loadedCustomCommands.login();
-      expect(taskSpy).to.have.been.calledOnceWith('createCustomToken', {
+      expect(taskSpy).to.have.been.calledOnceWith('authCreateCustomToken', {
         uid: 'foo',
         customClaims: undefined,
         tenantId: undefined,
@@ -94,7 +129,7 @@ describe('attachCustomCommands', () => {
       Cypress = { Commands: { add: addSpy }, env: envStub };
       attachCustomCommands({ cy, Cypress, firebase });
       await loadedCustomCommands.login('123ABC', undefined, 'tenant-id');
-      expect(taskSpy).to.have.been.calledOnceWith('createCustomToken', {
+      expect(taskSpy).to.have.been.calledOnceWith('authCreateCustomToken', {
         uid: '123ABC',
         customClaims: undefined,
         tenantId: 'tenant-id',
@@ -107,7 +142,7 @@ describe('attachCustomCommands', () => {
       attachCustomCommands({ cy, Cypress, firebase });
       envStub.withArgs('TEST_TENANT_ID').returns('env-tenant-id');
       await loadedCustomCommands.login('123ABC');
-      expect(taskSpy).to.have.been.calledOnceWith('createCustomToken', {
+      expect(taskSpy).to.have.been.calledOnceWith('authCreateCustomToken', {
         uid: '123ABC',
         customClaims: undefined,
         tenantId: 'env-tenant-id',
@@ -116,8 +151,23 @@ describe('attachCustomCommands', () => {
     });
   });
 
+  describe('cy.loginWithEmailAndPassword', () => {
+    it('is attached as a custom command', () => {
+      expect(addSpy).to.have.been.calledWith('loginWithEmailAndPassword');
+    });
+
+    // it('calls task', async () => {
+    //   // Return empty auth so logout is resolved
+    //   onAuthStateChanged = sinon.spy((authHandleFunc) => {
+    //     authHandleFunc();
+    //   });
+    //   await loadedCustomCommands.logout();
+    //   expect(onAuthStateChanged).to.have.been.calledOnce;
+    // });
+  });
+
   describe('cy.logout', () => {
-    it('Is attached as a custom command', () => {
+    it('is attached as a custom command', () => {
       expect(addSpy).to.have.been.calledWith('logout');
     });
 
@@ -132,7 +182,7 @@ describe('attachCustomCommands', () => {
   });
 
   describe('cy.callFirestore', () => {
-    it('Is attached as a custom command', () => {
+    it('is attached as a custom command', () => {
       expect(addSpy).to.have.been.calledWith('callFirestore');
     });
 
@@ -186,7 +236,7 @@ describe('attachCustomCommands', () => {
   });
 
   describe('cy.callRtdb', () => {
-    it('Is attached as a custom command', () => {
+    it('is attached as a custom command', () => {
       expect(addSpy).to.have.been.calledWith('callRtdb');
     });
 
@@ -278,70 +328,462 @@ describe('attachCustomCommands', () => {
     });
   });
 
-  describe('cy.getAuthUser', () => {
-    it('Is attached as a custom command', () => {
-      expect(addSpy).to.have.been.calledWith('getAuthUser');
-    });
+  describe('firebase auth functions', () => {
+    describe('cy.authCreateUser', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authCreateUser');
+      });
 
-    it('calls task with uid', async () => {
-      const uid = 'TESTING_USER_UID';
-      await loadedCustomCommands.getAuthUser(uid);
-      expect(taskSpy).to.have.been.calledWith('getAuthUser', {
-        uid,
-        tenantId: false,
+      it('calls task with parameters', async () => {
+        const uid = 'TESTING_USER_UID';
+        await loadedCustomCommands.authCreateUser({ uid });
+        expect(taskSpy).to.have.been.calledWith('authCreateUser', {
+          properties: { uid },
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authImportUsers', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authImportUsers');
+      });
+
+      it('calls task with parameters', async () => {
+        const uid1 = 'TESTING_USER_UID';
+        const uid2 = 'TESTING_USER_UID';
+        await loadedCustomCommands.authImportUsers([
+          { uid: uid1 },
+          { uid: uid2 },
+        ]);
+        expect(taskSpy).to.have.been.calledWith('authImportUsers', {
+          usersImport: [{ uid: uid1 }, { uid: uid2 }],
+          importOptions: undefined,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authListUsers', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authListUsers');
+      });
+
+      it('calls task with parameters', async () => {
+        await loadedCustomCommands.authListUsers(3);
+        expect(taskSpy).to.have.been.calledWith('authListUsers', {
+          maxResults: 3,
+          pageToken: undefined,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authGetUser', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authGetUser');
+      });
+
+      it('calls task with parameters', async () => {
+        const uid = 'TESTING_USER_UID';
+        await loadedCustomCommands.authGetUser(uid);
+        expect(taskSpy).to.have.been.calledWith('authGetUser', {
+          uid,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authGetUserByEmail', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authGetUserByEmail');
+      });
+
+      it('calls task with parameters', async () => {
+        const email = 'testuser@email.com';
+        await loadedCustomCommands.authGetUserByEmail(email);
+        expect(taskSpy).to.have.been.calledWith('authGetUserByEmail', {
+          email,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authGetUserByPhoneNumber', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authGetUserByPhoneNumber');
+      });
+
+      it('calls task with parameters', async () => {
+        const phoneNumber = 'A_PHONE_NUMBER';
+        await loadedCustomCommands.authGetUserByPhoneNumber(phoneNumber);
+        expect(taskSpy).to.have.been.calledWith('authGetUserByPhoneNumber', {
+          phoneNumber,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authGetUserByProviderUid', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authGetUserByProviderUid');
+      });
+
+      it('calls task with parameters', async () => {
+        const providerId = 'PROVIDER_ID';
+        const uid = 'TESTING_USER_UID';
+        await loadedCustomCommands.authGetUserByProviderUid(providerId, uid);
+        expect(taskSpy).to.have.been.calledWith('authGetUserByProviderUid', {
+          providerId,
+          uid,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authGetUsers', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authGetUsers');
+      });
+
+      it('calls task with parameters', async () => {
+        const uid = 'TESTING_USER_UID';
+        const email = 'testuser@email.com';
+        const phoneNumber = 'A_PHONE_NUMBER';
+        const providerId = 'PROVIDER_ID';
+        const identifiers = [
+          { uid },
+          { email },
+          { phoneNumber },
+          { providerId, providerUid: uid },
+        ];
+        await loadedCustomCommands.authGetUsers(identifiers);
+        expect(taskSpy).to.have.been.calledWith('authGetUsers', {
+          identifiers,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authUpdateUser', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authUpdateUser');
+      });
+
+      it('calls task with parameters', async () => {
+        const uid = 'TESTING_USER_UID';
+        const update = { displayName: 'Test User' };
+        await loadedCustomCommands.authUpdateUser(uid, update);
+        expect(taskSpy).to.have.been.calledWith('authUpdateUser', {
+          uid,
+          properties: update,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authSetCustomUserClaims', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authSetCustomUserClaims');
+      });
+
+      it('calls task with parameters', async () => {
+        const uid = 'TESTING_USER_UID';
+        const claims = { role: 'Admin' };
+        await loadedCustomCommands.authSetCustomUserClaims(uid, claims);
+        expect(taskSpy).to.have.been.calledWith('authSetCustomUserClaims', {
+          uid,
+          customClaims: claims,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authDeleteUser', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authDeleteUser');
+      });
+
+      it('calls task with parameters', async () => {
+        const uid = 'TESTING_USER_UID';
+        await loadedCustomCommands.authDeleteUser(uid);
+        expect(taskSpy).to.have.been.calledWith('authDeleteUser', {
+          uid,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authDeleteUsers', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authDeleteUsers');
+      });
+
+      it('calls task with parameters', async () => {
+        const uid1 = 'TESTING_USER_UID';
+        const uid2 = 'TESTING_USER_UID';
+        await loadedCustomCommands.authDeleteUsers([uid1, uid2]);
+        expect(taskSpy).to.have.been.calledWith('authDeleteUsers', {
+          uids: [uid1, uid2],
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authCreateCustomToken', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authCreateCustomToken');
+      });
+
+      it('calls task with parameters', async () => {
+        const uid = 'TESTING_USER_UID';
+        const claims = { role: 'Admin' };
+        await loadedCustomCommands.authCreateCustomToken(uid, claims);
+        expect(taskSpy).to.have.been.calledWith('authCreateCustomToken', {
+          uid,
+          customClaims: claims,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authCreateSessionCookie', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authCreateSessionCookie');
+      });
+
+      it('calls task with parameters', async () => {
+        const idToken = 'TESTING';
+        const cookieOpts = { expiresIn: 60 * 60 * 24 * 5 };
+        await loadedCustomCommands.authCreateSessionCookie(idToken, cookieOpts);
+        expect(taskSpy).to.have.been.calledWith('authCreateSessionCookie', {
+          idToken,
+          sessionCookieOptions: cookieOpts,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authVerifyIdToken', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authVerifyIdToken');
+      });
+
+      it('calls task with parameters', async () => {
+        const idToken = 'TESTING';
+        const checkRevoked = true;
+        await loadedCustomCommands.authVerifyIdToken(idToken, checkRevoked);
+        expect(taskSpy).to.have.been.calledWith('authVerifyIdToken', {
+          idToken,
+          checkRevoked,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authRevokeRefreshTokens', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authRevokeRefreshTokens');
+      });
+
+      it('calls task with parameters', async () => {
+        const uid = 'TESTING_USER_UID';
+        await loadedCustomCommands.authRevokeRefreshTokens(uid);
+        expect(taskSpy).to.have.been.calledWith('authRevokeRefreshTokens', {
+          uid,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authGenerateEmailVerificationLink', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith(
+          'authGenerateEmailVerificationLink',
+        );
+      });
+
+      it('calls task with parameters', async () => {
+        const email = 'testuser@email.com';
+        const actionCodeSettings = { url: 'https://example.com' };
+        await loadedCustomCommands.authGenerateEmailVerificationLink(
+          email,
+          actionCodeSettings,
+        );
+        expect(taskSpy).to.have.been.calledWith(
+          'authGenerateEmailVerificationLink',
+          {
+            email,
+            actionCodeSettings,
+            tenantId: false,
+          },
+        );
+      });
+    });
+    describe('cy.authGeneratePasswordResetLink', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authGeneratePasswordResetLink');
+      });
+
+      it('calls task with parameters', async () => {
+        const email = 'testuser@email.com';
+        const actionCodeSettings = { url: 'https://example.com' };
+        await loadedCustomCommands.authGeneratePasswordResetLink(
+          email,
+          actionCodeSettings,
+        );
+        expect(taskSpy).to.have.been.calledWith(
+          'authGeneratePasswordResetLink',
+          {
+            email,
+            actionCodeSettings,
+            tenantId: false,
+          },
+        );
+      });
+    });
+    describe('cy.authGenerateSignInWithEmailLink', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith(
+          'authGenerateSignInWithEmailLink',
+        );
+      });
+
+      it('calls task with parameters', async () => {
+        const email = 'testuser@email.com';
+        const actionCodeSettings = { url: 'https://example.com' };
+        await loadedCustomCommands.authGenerateSignInWithEmailLink(
+          email,
+          actionCodeSettings,
+        );
+        expect(taskSpy).to.have.been.calledWith(
+          'authGenerateSignInWithEmailLink',
+          {
+            email,
+            actionCodeSettings,
+            tenantId: false,
+          },
+        );
+      });
+    });
+    describe('cy.authGenerateVerifyAndChangeEmailLink', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith(
+          'authGenerateVerifyAndChangeEmailLink',
+        );
+      });
+
+      it('calls task with parameters', async () => {
+        const email = 'testuser@email.com';
+        const newEmail = 'second@email.com';
+        const actionCodeSettings = { url: 'https://example.com' };
+        await loadedCustomCommands.authGenerateVerifyAndChangeEmailLink(
+          email,
+          newEmail,
+          actionCodeSettings,
+        );
+        expect(taskSpy).to.have.been.calledWith(
+          'authGenerateVerifyAndChangeEmailLink',
+          {
+            email,
+            newEmail,
+            actionCodeSettings,
+            tenantId: false,
+          },
+        );
+      });
+    });
+    describe('cy.authCreateProviderConfig', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authCreateProviderConfig');
+      });
+
+      it('calls task with parameters', async () => {
+        const providerConfig = {
+          clientId: 'CLIENT_ID',
+          issuer: 'ISSUER',
+        };
+        await loadedCustomCommands.authCreateProviderConfig(providerConfig);
+        expect(taskSpy).to.have.been.calledWith('authCreateProviderConfig', {
+          providerConfig,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authGetProviderConfig', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authGetProviderConfig');
+      });
+
+      it('calls task with parameters', async () => {
+        const providerId = 'PROVIDER_ID';
+        await loadedCustomCommands.authGetProviderConfig(providerId);
+        expect(taskSpy).to.have.been.calledWith('authGetProviderConfig', {
+          providerId,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authListProviderConfigs', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authListProviderConfigs');
+      });
+
+      it('calls task with parameters', async () => {
+        const providerFilter = { type: 'oidc', maxResults: 2 };
+        await loadedCustomCommands.authListProviderConfigs(providerFilter);
+        expect(taskSpy).to.have.been.calledWith('authListProviderConfigs', {
+          providerFilter,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authUpdateProviderConfig', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authUpdateProviderConfig');
+      });
+
+      it('calls task with parameters', async () => {
+        const providerId = 'PROVIDER_ID';
+        const providerConfig = {
+          clientId: 'CLIENT_ID',
+          issuer: 'ISSUER',
+        };
+        await loadedCustomCommands.authUpdateProviderConfig(
+          providerId,
+          providerConfig,
+        );
+        expect(taskSpy).to.have.been.calledWith('authUpdateProviderConfig', {
+          providerId,
+          providerConfig,
+          tenantId: false,
+        });
+      });
+    });
+    describe('cy.authDeleteProviderConfig', () => {
+      it('is attached as a custom command', () => {
+        expect(addSpy).to.have.been.calledWith('authDeleteProviderConfig');
+      });
+
+      it('calls task with parameters', async () => {
+        const providerId = 'PROVIDER_ID';
+        await loadedCustomCommands.authDeleteProviderConfig(providerId);
+        expect(taskSpy).to.have.been.calledWith('authDeleteProviderConfig', {
+          providerId,
+          tenantId: false,
+        });
       });
     });
   });
 
+  describe('cy.createUserWithClaims', () => {
+    it('is attached as a custom command', () => {
+      expect(addSpy).to.have.been.calledWith('createUserWithClaims');
+    });
+  });
+
+  describe('cy.deleteAllAuthUsers', () => {
+    it('is attached as a custom command', () => {
+      expect(addSpy).to.have.been.calledWith('deleteAllAuthUsers');
+    });
+  });
+
   describe('options', () => {
-    it('Aliases login command', () => {
-      const commandNames = { login: 'testing' };
-      attachCustomCommands({ cy, Cypress, firebase }, { commandNames });
-      expect(addSpy).to.have.been.calledWith(commandNames.login);
-      expect(addSpy).to.have.been.calledWith('logout');
-      expect(addSpy).to.have.been.calledWith('callRtdb');
-      expect(addSpy).to.have.been.calledWith('callFirestore');
-      expect(addSpy).to.have.been.calledWith('getAuthUser');
-    });
-
-    it('Aliases logout command', () => {
-      const commandNames = { logout: 'testing' };
-      attachCustomCommands({ cy, Cypress, firebase }, { commandNames });
-      expect(addSpy).to.have.been.calledWith(commandNames.logout);
-      expect(addSpy).to.have.been.calledWith('login');
-      expect(addSpy).to.have.been.calledWith('callRtdb');
-      expect(addSpy).to.have.been.calledWith('callFirestore');
-      expect(addSpy).to.have.been.calledWith('getAuthUser');
-    });
-
-    it('Aliases callRtdb command', () => {
-      const commandNames = { callRtdb: 'testing' };
-      attachCustomCommands({ cy, Cypress, firebase }, { commandNames });
-      expect(addSpy).to.have.been.calledWith(commandNames.callRtdb);
-      expect(addSpy).to.have.been.calledWith('login');
-      expect(addSpy).to.have.been.calledWith('logout');
-      expect(addSpy).to.have.been.calledWith('callFirestore');
-      expect(addSpy).to.have.been.calledWith('getAuthUser');
-    });
-
-    it('Aliases callFirestore command', () => {
-      const commandNames = { callFirestore: 'testing' };
-      attachCustomCommands({ cy, Cypress, firebase }, { commandNames });
-      expect(addSpy).to.have.been.calledWith(commandNames.callFirestore);
-      expect(addSpy).to.have.been.calledWith('login');
-      expect(addSpy).to.have.been.calledWith('logout');
-      expect(addSpy).to.have.been.calledWith('callRtdb');
-      expect(addSpy).to.have.been.calledWith('getAuthUser');
-    });
-
-    it('Aliases getAuthUser command', () => {
-      const commandNames = { getAuthUser: 'testing' };
-      attachCustomCommands({ cy, Cypress, firebase }, { commandNames });
-      expect(addSpy).to.have.been.calledWith(commandNames.getAuthUser);
-      expect(addSpy).to.have.been.calledWith('login');
-      expect(addSpy).to.have.been.calledWith('logout');
-      expect(addSpy).to.have.been.calledWith('callRtdb');
-      expect(addSpy).to.have.been.calledWith('callFirestore');
+    allCommandNames.forEach((commandName) => {
+      it(`Aliases ${commandName} command`, () => {
+        const commandNames = { [commandName]: 'testing' };
+        attachCustomCommands({ cy, Cypress, firebase }, { commandNames });
+        expect(addSpy).to.have.been.calledWith('testing');
+        allCommandNames
+          .filter((name) => name !== commandName)
+          .forEach((name) => {
+            expect(addSpy).to.have.been.calledWith(name);
+          });
+      });
     });
   });
 });

--- a/test/unit/plugin.spec.ts
+++ b/test/unit/plugin.spec.ts
@@ -58,9 +58,9 @@ describe('plugin', () => {
     );
     expect(results).to.be.an('object');
     expect(onFuncSpy).to.have.been.calledOnceWith('task');
-    expect(assignedTasksObj).to.have.property('createCustomToken');
+    expect(assignedTasksObj).to.have.property('authCreateCustomToken');
     const uid = 'SomeUid';
-    (assignedTasksObj as any).createCustomToken({ uid });
+    (assignedTasksObj as any).authCreateCustomToken({ uid });
     expect(createCustomTokenSpy).to.have.been.calledWith(uid);
   });
 });


### PR DESCRIPTION
### Description
I was in need of some Firebase Auth functions other than those provided by login, logout and getAuthUser, mainly functions like createAuthUser, importAuthUsers and deleteAuthUser(s).
Whilst adding those functions I thought, 'Why not add all of them, maybe I need them some day or someone else might?'

I had to rewrite plugin.ts to be more generalised.
I was unsure whether to give every auth function it's own task and custom command, or to to something like with callRtdb and callFirestore, where the first argument specified which function actually gets called.
Because of the plethora of different arguments needed in the Auth functions, I chose for the former. Also because this was quickest to implement. It does however 'pollute' the tasks and custom commands with lots of them.
If the latter approach–where some of the functions get grouped and then work similar to callRtdb/callFirestore–is preferred, I am willing to alter the PR to do so.
Another solution to prevent the 'pollution' is to be able to disable custom commands entirely, by adding the possibility to set options.commandNames[someCommandName] to false, which would then skip the Cypress.Commands.add code for that function.

I haven't added tests or made changes to readme.md because I didn't want to put in that effort before knowing this PR has the possibility of getting merged. If so, I would be adding tests and documentation as well.

The auth tasks are:
- createAuthUser
- importAuthUsers
- listAuthUsers
- getAuthUser (added tenantId param)
- getAuthUserByEmail
- getAuthUserByPhoneNumber
- getAuthUserByProviderUid
- getAuthUsers
- updateAuthUser
- setAuthUserCustomClaims
- deleteAuthUser
- deleteAuthUsers
- createCustomToken
- createSessionCookie
- verifyIdToken
- revokeRefreshTokens
- generateEmailVerificationLink
- generatePasswordResetLink
- generateSignInWithEmailLink
- generateVerifyAndChangeEmailLink
- createProviderConfig
- getProviderConfig
- listProviderConfigs
- updateProviderCondig
- deleteProviderConfig

The custom command are:
- _same as tasks above_
- loginWithEmailAndPassword
- deleteAllAuthUsers