### PR TITLE
chore: add note about SERVICE_ACCOUNT env var for local

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you are interested in what drove the need for this checkout [the why section]
    - _suggested_ Set `GCLOUD_PROJECT` environment variable to match the Google Project you would like to use. This needs to be on the process running cypress, so it should be before `cypress open` or `cypress run` in npm scripts. cross-env is a helpful way to do this to support multiple platforms and is how it is done in examples.
    - Pass `projectId` into `cypressFirebasePlugin` options when initializing (see comment in next step)
 1. Generate and download a service account as described in [the firebase-admin setup documentation](https://firebase.google.com/docs/admin/setup#initialize-sdk). Save this to a local file within the project which you confirm is within your `.gitignore` - often `./serviceAccount.json`. Make sure YOU DO NOT COMMIT THIS FILE - it is sensitive and will give others admin access to your project.
+   - **Note**: When running tests locally, ensure the `SERVICE_ACCOUNT` is in your environment variables. I.E. `SERVICE_ACCOUNT=$(cat ./serviceAccount.json) cypress open`
 1. Set the following config in your `cypress.config.js` or `cypress.config.ts`
 
 With [Firebase Web SDK versions up to 8](https://firebase.google.com/docs/web/modular-upgrade)


### PR DESCRIPTION
### Description

The contents of `./serviceAccount.json` file are not picked up by default when running cypress-firebase locally, it possible having the contents of this file in your env as SERVICE_ACCOUNT used to be in the Google Service Account setup docs, but are not there anymore. 

It seems the `getServiceAccount` function doesn't throw when this is not present, leading to a `getaddrinfo ENOTFOUND metadata cypress-firebase` error that doesn't help any.

Hope this helps people in the future! 

### Screenshots (if appropriate)
