### PR TITLE
fix(firestore): support unlimited number of where conditions

### DIFF
--- a/src/firebase-utils.ts
+++ b/src/firebase-utils.ts
@@ -274,12 +274,13 @@ export function slashPathToFirestoreRef(
     typeof ref.where === 'function'
   ) {
     if (Array.isArray(options.where[0])) {
-      const [where1, where2] = options.where as WhereOptions[];
-      ref = applyWhere(
-        applyWhere(ref, where1, options.statics || firestoreStatics),
-        where2,
-        options.statics || firestoreStatics,
-      );
+      (options.where as WhereOptions[]).forEach((whereCondition) => {
+        ref = applyWhere(
+          ref,
+          whereCondition,
+          options.statics || firestoreStatics,
+        );
+      });
     } else {
       ref = applyWhere(
         ref,

--- a/test/unit/tasks.spec.ts
+++ b/test/unit/tasks.spec.ts
@@ -168,8 +168,17 @@ describe('tasks', () => {
       it('supports multi-where', async () => {
         await projectFirestoreRef.set(testProject);
         const secondProjectId = 'some';
-        const secondProject = { name: 'another', status: 'asdf' };
+        const secondProject = {
+          name: 'another',
+          status: 'asdf',
+          anotherProperty: 'ghjk',
+        };
         await projectsFirestoreRef.doc(secondProjectId).set(secondProject);
+        await projectsFirestoreRef.doc('confounding').set({
+          name: 'another',
+          status: 'asdf',
+          anotherProperty: 'we-must-not-match-this',
+        });
         const result = await tasks.callFirestore(
           adminApp,
           'get',
@@ -178,9 +187,11 @@ describe('tasks', () => {
             where: [
               ['name', '==', secondProject.name],
               ['status', '==', secondProject.status],
+              ['anotherProperty', '==', secondProject.anotherProperty],
             ],
           },
         );
+        expect(result).to.have.length(1);
         expect(result[0]).to.have.property('id', secondProjectId);
         expect(result[0]).to.have.property('name', secondProject.name);
         expect(result[0]).to.have.property('status', secondProject.status);


### PR DESCRIPTION
### Description

Fixes #1313

Adds a failing test first, where we have two documents that match the first two where conditions. If we are processing all three where conditions correctly, the query should uniquely identify a single document instead, to pass.

Verified the fix in a Cypress project of mine