### PR TITLE
chore(dev-deps): update dependency typescript to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint-staged": "17.0.7",
     "rimraf": "6.1.3",
     "size-limit": "12.1.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.8"
   },
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "outDir": "lib",
     "rootDir": "./src",
     "importHelpers": true,
-    "downlevelIteration": true,
     "allowSyntheticDefaultImports": true
   },
   "typeRoots": ["./types", "./node_modules/@types"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4163,7 +4163,7 @@ __metadata:
     lint-staged: "npm:17.0.7"
     rimraf: "npm:6.1.3"
     size-limit: "npm:12.1.0"
-    typescript: "npm:5.9.3"
+    typescript: "npm:6.0.3"
     vitest: "npm:4.1.8"
   peerDependencies:
     firebase-admin: ">=11.0.0"
@@ -9676,23 +9676,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Updates TypeScript 5.9.3 → **6.0.3**.

One required change: TypeScript 6.0 deprecates `downlevelIteration` (build fails with `TS5101`). It was removed from `tsconfig.json` rather than silenced with `ignoreDeprecations`, because it was already a no-op for this project — it only affects emit for targets below ES2015, and this project targets ES2022.

### Verification

- `yarn build`: clean (exit 0)
- `yarn size`: both exports at 8.71 kB, within the 9 kB budget (output unchanged)
- `yarn test`: 6 files, 170 tests passing
- `yarn lint` / `yarn format:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)