### PR TITLE
feat: support firebase-admin v14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ examples/*/.yarn/*
 !examples/*/.yarn/releases
 !examples/*/.yarn/sdks
 !examples/*/.yarn/versions
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ The two sides are linked by `taskSettingKeys` in `src/tasks.ts` — an ordered m
 
 ### Constraints
 
-- `adminInstance` is intentionally typed `any` and accessed through the namespaced API (`admin.firestore()`, `admin.auth()`) so the same code works across firebase-admin versions; types are imported from `firebase-admin` as type-only imports.
-- The package is consumed in both browser and Node contexts; `package.json`'s `browser` field stubs `fs`/`os`/`path`. Don't add runtime dependencies (it's advertised as 0-dependency) or Node-only imports to browser-side code paths.
+- `adminInstance` is intentionally typed `any` and accessed through the legacy namespaced API shape (`admin.firestore()`, `admin.auth()`) so the same code works across firebase-admin versions. firebase-admin v14+ removed that API, so `plugin.ts` detects modular modules via `isModularAdmin` and wraps them with `adaptModularAdmin` (both in `firebase-utils.ts`) to recreate the legacy shape; the adapter lazily `require`s `firebase-admin/*` subpaths. Types are imported from `firebase-admin/*` subpaths as type-only imports.
+- The package is consumed in both browser and Node contexts; `package.json`'s `browser` field stubs `fs`/`os`/`path` and the `firebase-admin/*` subpaths used by the adapter. Don't add runtime dependencies (it's advertised as 0-dependency) or Node-only imports to browser-side code paths.
 - `size-limit` enforces a 9kb budget on each of the two exports (`attachCustomCommands`, `plugin`).
 - Biome handles lint + format (single quotes, spaces). `console` calls are errors; intentional logging uses `// biome-ignore lint/suspicious/noConsole: Intentional logging`.
 - Public API surface is only what `src/index.ts` exports: `attachCustomCommands` and `plugin` (plus types).

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@vitest/coverage-v8": "4.1.8",
     "cypress": "15.17.0",
     "firebase": "12.14.0",
-    "firebase-admin": "13.10.0",
+    "firebase-admin": "14.0.0",
     "firebase-tools": "15.20.0",
     "husky": "9.1.7",
     "lint-staged": "17.0.7",
@@ -67,7 +67,11 @@
   "browser": {
     "fs": false,
     "os": false,
-    "path": false
+    "path": false,
+    "firebase-admin/app": false,
+    "firebase-admin/auth": false,
+    "firebase-admin/database": false,
+    "firebase-admin/firestore": false
   },
   "files": [
     "bin",

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -1,4 +1,5 @@
-import type { auth, firestore } from 'firebase-admin';
+import type * as auth from 'firebase-admin/auth';
+import type * as firestore from 'firebase-admin/firestore';
 import type { authCreateUser } from './tasks';
 import { type TaskNameToParams, typedTask } from './tasks';
 
@@ -25,7 +26,7 @@ export interface FixtureData {
   [k: string]: any;
 }
 
-export type WhereOptions = [string, FirebaseFirestore.WhereFilterOp, any];
+export type WhereOptions = [string, firestore.WhereFilterOp, any];
 
 /**
  * Options for callFirestore custom Cypress command.
@@ -51,7 +52,7 @@ export interface CallFirestoreOptions {
   /**
    * Order documents
    */
-  orderBy?: string | [string, FirebaseFirestore.OrderByDirection];
+  orderBy?: string | [string, firestore.OrderByDirection];
   /**
    * Limit to n number of documents
    */

--- a/src/attachCustomCommands.ts
+++ b/src/attachCustomCommands.ts
@@ -29,6 +29,16 @@ export interface FixtureData {
 export type WhereOptions = [string, firestore.WhereFilterOp, any];
 
 /**
+ * Subset of Firestore statics used by cypress-firebase. Both the legacy
+ * namespaced API (i.e. admin.firestore on firebase-admin v11-13) and the
+ * modular firebase-admin/firestore module (v14+) satisfy this shape.
+ */
+export type FirestoreStatics = Pick<
+  typeof firestore,
+  'FieldValue' | 'Timestamp' | 'GeoPoint'
+>;
+
+/**
  * Options for callFirestore custom Cypress command.
  */
 export interface CallFirestoreOptions {
@@ -65,7 +75,7 @@ export interface CallFirestoreOptions {
    * Firestore statics (i.e. admin.firestore). This should only be needed during
    * testing due to @firebase/testing not containing statics
    */
-  statics?: typeof firestore;
+  statics?: FirestoreStatics;
 }
 
 /**

--- a/src/firebase-utils.ts
+++ b/src/firebase-utils.ts
@@ -2,6 +2,7 @@ import type { App, AppOptions, Credential } from 'firebase-admin/app';
 import type * as firestore from 'firebase-admin/firestore';
 import type {
   CallFirestoreOptions,
+  FirestoreStatics,
   WhereOptions,
 } from './attachCustomCommands';
 import { convertValueToTimestampOrGeoPointIfPossible } from './tasks';
@@ -10,7 +11,8 @@ import { convertValueToTimestampOrGeoPointIfPossible } from './tasks';
  * Firestore function from a firebase-admin instance (invoking gets the
  * instance) which also carries statics such as FieldValue and Timestamp
  */
-export type FirestoreStatics = (() => firestore.Firestore) & typeof firestore;
+export type FirestoreFunctionWithStatics = (() => firestore.Firestore) &
+  FirestoreStatics;
 
 /**
  * Check whether the provided firebase-admin instance uses the modular API
@@ -317,7 +319,7 @@ export function isDocPath(slashPath: string): boolean {
 export function applyWhere(
   ref: firestore.CollectionReference | firestore.Query,
   whereSetting: WhereOptions,
-  firestoreStatics: typeof firestore,
+  firestoreStatics: FirestoreStatics,
 ): firestore.Query {
   const [param, filterOp, val] = whereSetting as WhereOptions;
   return ref.where(
@@ -335,7 +337,7 @@ export function applyWhere(
  * @returns Ref at slash path
  */
 export function slashPathToFirestoreRef(
-  firestoreStatics: FirestoreStatics,
+  firestoreStatics: FirestoreFunctionWithStatics,
   slashPath: string,
   options?: CallFirestoreOptions,
 ):

--- a/src/firebase-utils.ts
+++ b/src/firebase-utils.ts
@@ -1,9 +1,64 @@
-import type { AppOptions, app, credential, firestore } from 'firebase-admin';
+import type { App, AppOptions, Credential } from 'firebase-admin/app';
+import type * as firestore from 'firebase-admin/firestore';
 import type {
   CallFirestoreOptions,
   WhereOptions,
 } from './attachCustomCommands';
 import { convertValueToTimestampOrGeoPointIfPossible } from './tasks';
+
+/**
+ * Firestore function from a firebase-admin instance (invoking gets the
+ * instance) which also carries statics such as FieldValue and Timestamp
+ */
+export type FirestoreStatics = (() => firestore.Firestore) & typeof firestore;
+
+/**
+ * Check whether the provided firebase-admin instance uses the modular API
+ * (firebase-admin v14+) which no longer includes the legacy namespaced API
+ * @param adminInstance - firebase-admin instance to check
+ * @returns Whether the instance is a modular firebase-admin module
+ */
+export function isModularAdmin(adminInstance: any): boolean {
+  return (
+    !!adminInstance &&
+    typeof adminInstance.getApps === 'function' &&
+    typeof adminInstance.firestore !== 'function'
+  );
+}
+
+/**
+ * Adapt a modular firebase-admin module (v14+) to the legacy namespaced
+ * shape used internally (i.e. admin.firestore(), admin.auth()). App lifecycle
+ * and credential functions come from the passed module; service accessors are
+ * loaded lazily from firebase-admin subpath entry points (a peer dependency)
+ * so they are only required in the node context - package.json's "browser"
+ * field stubs them out of browser bundles.
+ * @param adminInstance - Modular firebase-admin module (v14+)
+ * @returns Object matching the legacy namespaced firebase-admin API shape
+ */
+export function adaptModularAdmin(adminInstance: any): any {
+  const firestoreModule = require('firebase-admin/firestore');
+  const { getAuth } = require('firebase-admin/auth');
+  const { getDatabase } = require('firebase-admin/database');
+  const firestoreFn = (app?: any) =>
+    firestoreModule.getFirestore(app || adminInstance.getApp());
+  // Attach statics (FieldValue, Timestamp, GeoPoint, etc.) like the legacy API
+  Object.assign(firestoreFn, firestoreModule);
+  return {
+    get apps() {
+      return adminInstance.getApps();
+    },
+    initializeApp: (appOptions?: AppOptions) =>
+      adminInstance.initializeApp(appOptions),
+    credential: {
+      cert: adminInstance.cert,
+      applicationDefault: adminInstance.applicationDefault,
+    },
+    firestore: firestoreFn,
+    auth: (app?: any) => getAuth(app || adminInstance.getApp()),
+    database: (app?: any) => getDatabase(app || adminInstance.getApp()),
+  };
+}
 
 /**
  * Check whether a value is a string or not
@@ -20,7 +75,7 @@ export function isString(valToCheck: any): boolean {
  * defaults to port 8080 and servicePath "localhost".
  * @returns Firestore settings to be passed to firebase.firestore().settings
  */
-function firestoreSettingsFromEnv(): FirebaseFirestore.Settings {
+function firestoreSettingsFromEnv(): firestore.Settings {
   const { FIRESTORE_EMULATOR_HOST } = process.env;
   if (
     typeof FIRESTORE_EMULATOR_HOST === 'undefined' ||
@@ -74,9 +129,7 @@ function getServiceAccount(): ServiceAccount | undefined {
  * @param adminInstance - firebase-admin instance to initialize
  * @returns Firebase admin credential
  */
-function getFirebaseCredential(
-  adminInstance: any,
-): credential.Credential | undefined {
+function getFirebaseCredential(adminInstance: any): Credential | undefined {
   const serviceAccount = getServiceAccount();
   // Add service account credential if it exists so that custom auth tokens can be generated
   if (serviceAccount) {
@@ -122,7 +175,7 @@ export function initializeFirebase(
   adminInstance: any,
   overrideConfig?: AppOptions,
   protectProduction?: protectProduction,
-): app.App {
+): App {
   try {
     // TODO: Look into using @firebase/testing in place of admin here to allow for
     // usage of clearFirestoreData (see https://github.com/prescottprue/cypress-firebase/issues/73 for more info)
@@ -264,16 +317,13 @@ export function isDocPath(slashPath: string): boolean {
 export function applyWhere(
   ref: firestore.CollectionReference | firestore.Query,
   whereSetting: WhereOptions,
-  firestoreStatics: app.App['firestore'],
+  firestoreStatics: typeof firestore,
 ): firestore.Query {
   const [param, filterOp, val] = whereSetting as WhereOptions;
   return ref.where(
     param,
     filterOp,
-    convertValueToTimestampOrGeoPointIfPossible(
-      val,
-      firestoreStatics as typeof firestore,
-    ),
+    convertValueToTimestampOrGeoPointIfPossible(val, firestoreStatics),
   );
 }
 
@@ -285,7 +335,7 @@ export function applyWhere(
  * @returns Ref at slash path
  */
 export function slashPathToFirestoreRef(
-  firestoreStatics: app.App['firestore'],
+  firestoreStatics: FirestoreStatics,
   slashPath: string,
   options?: CallFirestoreOptions,
 ):
@@ -357,7 +407,7 @@ export function slashPathToFirestoreRef(
  */
 function deleteQueryBatch(
   db: any,
-  query: FirebaseFirestore.CollectionReference | FirebaseFirestore.Query,
+  query: firestore.CollectionReference | firestore.Query,
   resolve: (value?: any) => any,
   reject: any,
 ): void {
@@ -400,7 +450,7 @@ function deleteQueryBatch(
  */
 export function deleteCollection(
   db: any,
-  refOrQuery: FirebaseFirestore.CollectionReference | FirebaseFirestore.Query,
+  refOrQuery: firestore.CollectionReference | firestore.Query,
   options?: CallFirestoreOptions,
 ): Promise<any> {
   let baseQuery = refOrQuery.orderBy('__name__');

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,8 +1,13 @@
-import type { AppOptions } from 'firebase-admin';
+import type { AppOptions } from 'firebase-admin/app';
 import extendWithFirebaseConfig, {
   type ExtendedCypressConfig,
 } from './extendWithFirebaseConfig';
-import { initializeFirebase, type protectProduction } from './firebase-utils';
+import {
+  adaptModularAdmin,
+  initializeFirebase,
+  isModularAdmin,
+  type protectProduction,
+} from './firebase-utils';
 import type { TaskName } from './tasks';
 import tasks, {
   type TaskNameToParams,
@@ -34,10 +39,15 @@ export default function pluginWithTasks(
   overrideConfig?: AppOptions,
   pluginConfig?: PluginConfig,
 ): ExtendedCypressConfig {
+  // Adapt modular firebase-admin (v14+) to the legacy namespaced shape used
+  // by tasks so the same code works across firebase-admin versions
+  const admin = isModularAdmin(adminInstance)
+    ? adaptModularAdmin(adminInstance)
+    : adminInstance;
   // Only initialize admin instance if it hasn't already been initialized
-  if (adminInstance.apps && adminInstance.apps.length === 0) {
+  if (admin.apps && admin.apps.length === 0) {
     initializeFirebase(
-      adminInstance,
+      admin,
       overrideConfig,
       pluginConfig && pluginConfig.protectProduction,
     );
@@ -57,7 +67,7 @@ export default function pluginWithTasks(
         (sk: string) => taskSettings[sk],
       );
       // @ts-expect-error - TS cannot know that the right amount of args are passed
-      return tasks[taskName](adminInstance, ...taskArgs);
+      return tasks[taskName](admin, ...taskArgs);
     };
     return acc;
   }, {} as tasksType);

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -6,6 +6,7 @@ import type {
   CallFirestoreOptions,
   CallRtdbOptions,
   FirestoreAction,
+  FirestoreStatics,
   FixtureData,
   RTDBAction,
 } from './attachCustomCommands';
@@ -75,7 +76,7 @@ function getAuth(
  */
 export function convertValueToTimestampOrGeoPointIfPossible(
   dataVal: any,
-  firestoreStatics: typeof firestore,
+  firestoreStatics: FirestoreStatics,
 ): firestore.FieldValue {
   if (
     (dataVal && dataVal._methodName === 'serverTimestamp') ||
@@ -116,7 +117,7 @@ export function convertValueToTimestampOrGeoPointIfPossible(
  */
 function getDataWithTimestampsAndGeoPoints(
   data: firestore.DocumentData,
-  firestoreStatics: typeof firestore,
+  firestoreStatics: FirestoreStatics,
 ): Record<string, any> {
   // Exit if no statics are passed
   if (!firestoreStatics) {
@@ -294,7 +295,7 @@ export async function callFirestore(
       // Use static option if passed (tests), otherwise fallback to statics on adminInstance
       // Tests do not have statics since they are using @firebase/testing
       (options && options.statics) ||
-        (adminInstance.firestore as typeof firestore),
+        (adminInstance.firestore as FirestoreStatics),
     );
 
     if (action === 'set') {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,4 +1,6 @@
-import type { app, auth, database, firestore } from 'firebase-admin';
+import type * as auth from 'firebase-admin/auth';
+import type * as database from 'firebase-admin/database';
+import type * as firestore from 'firebase-admin/firestore';
 import type {
   AttachCustomCommandParams,
   CallFirestoreOptions,
@@ -226,7 +228,7 @@ export async function callRtdb(
  * @returns Promise which resolves with results of calling Firestore
  */
 export async function callFirestore(
-  adminInstance: app.App,
+  adminInstance: any,
   action: FirestoreAction,
   actionPath: string,
   options?: CallFirestoreOptions,
@@ -248,7 +250,7 @@ export async function callFirestore(
         snap.docs.length &&
         typeof snap.docs.map === 'function'
       ) {
-        return snap.docs.map((docSnap: FirebaseFirestore.DocumentSnapshot) => ({
+        return snap.docs.map((docSnap: firestore.DocumentSnapshot) => ({
           ...docSnap.data(),
           id: docSnap.id,
         }));
@@ -266,7 +268,7 @@ export async function callFirestore(
               adminInstance.firestore,
               actionPath,
               options,
-            ) as FirebaseFirestore.DocumentReference
+            ) as firestore.DocumentReference
           ).delete()
         : deleteCollection(
             adminInstance.firestore(),
@@ -274,9 +276,7 @@ export async function callFirestore(
               adminInstance.firestore,
               actionPath,
               options,
-            ) as
-              | FirebaseFirestore.CollectionReference
-              | FirebaseFirestore.Query,
+            ) as firestore.CollectionReference | firestore.Query,
             options,
           );
       await deletePromise;
@@ -306,7 +306,7 @@ export async function callFirestore(
           options && options.merge
             ? ({
                 merge: options.merge,
-              } as FirebaseFirestore.SetOptions)
+              } as firestore.SetOptions)
             : (undefined as any),
         );
     }

--- a/test/unit/plugin.spec.ts
+++ b/test/unit/plugin.spec.ts
@@ -203,4 +203,40 @@ describe('plugin', () => {
       });
     });
   });
+
+  describe('modular firebase-admin (v14+)', () => {
+    it('Should adapt instances without the legacy namespaced API', () => {
+      let assignedTasksObj: any;
+      const onFuncSpy = vi.fn((_action, tasksObj) => {
+        assignedTasksObj = tasksObj;
+      });
+      const initializeAppSpy = vi.fn(() => ({}));
+      const applicationDefaultSpy = vi.fn(() => ({
+        projectId: 'test-project',
+      }));
+
+      process.env.FIREBASE_DATABASE_EMULATOR_HOST = '';
+      process.env.FIRESTORE_EMULATOR_HOST = '';
+      process.env.FIREBASE_AUTH_EMULATOR_HOST = '';
+
+      const results = pluginWithTasks(
+        onFuncSpy as unknown as Cypress.PluginEvents,
+        {} as Cypress.PluginConfigOptions,
+        {
+          getApps: () => [],
+          getApp: () => ({}),
+          initializeApp: initializeAppSpy,
+          cert: vi.fn(),
+          applicationDefault: applicationDefaultSpy,
+        },
+      );
+      expect(results).toBeTypeOf('object');
+      expect(onFuncSpy).toHaveBeenCalledTimes(1);
+      expect(onFuncSpy).toHaveBeenCalledWith('task', expect.any(Object));
+      // Initialization goes through the adapted legacy-shaped instance
+      expect(applicationDefaultSpy).toHaveBeenCalledTimes(1);
+      expect(initializeAppSpy).toHaveBeenCalledTimes(1);
+      expect(assignedTasksObj).toHaveProperty('callFirestore');
+    });
+  });
 });

--- a/test/unit/tasks.spec.ts
+++ b/test/unit/tasks.spec.ts
@@ -13,6 +13,7 @@ import {
   it,
   vi,
 } from 'vitest';
+import { adaptModularAdmin } from '../../src/firebase-utils';
 import * as tasks from '../../src/tasks';
 
 const PROJECTS_COLLECTION = 'projects';
@@ -24,11 +25,14 @@ const testProject = { name: 'project 1' };
  * Initialize firebase-admin SDK with emulator settings for RTDB
  * Using conditional credential handling for Node.js compatibility
  */
-const adminApp = admin.initializeApp({
+admin.initializeApp({
   projectId: process.env.GCLOUD_PROJECT,
   databaseURL: `http://${process.env.FIREBASE_DATABASE_EMULATOR_HOST}?ns=${process.env.GCLOUD_PROJECT}`,
-  credential: admin.credential.applicationDefault(),
+  credential: admin.applicationDefault(),
 });
+
+// Legacy-shaped admin instance (matches what plugin.ts passes to tasks)
+const adminApp = adaptModularAdmin(admin);
 
 const projectsFirestoreRef = adminApp
   .firestore()
@@ -51,11 +55,8 @@ describe('tasks', () => {
   });
   afterAll(async () => {
     // Cleanup all apps (keeps active listeners from preventing JS from exiting)
-    await adminApp.delete();
+    await Promise.all(admin.getApps().map((app) => admin.deleteApp(app)));
     await testEnv.cleanup();
-
-    // Cleanup only this tests's instance of firebase-admin app
-    await Promise.all(admin.apps.map((app) => app?.delete()));
   });
 
   describe('callFirestore', () => {
@@ -132,19 +133,19 @@ describe('tasks', () => {
       it('supports where with timestamp', async () => {
         const projectId = 'one-where-timestamp';
         const currentDate = new Date();
-        await projectsFirestoreRef
-          .doc(projectId)
-          .set({ dateField: admin.firestore.Timestamp.fromDate(currentDate) });
+        await projectsFirestoreRef.doc(projectId).set({
+          dateField: adminApp.firestore.Timestamp.fromDate(currentDate),
+        });
         const result = await tasks.callFirestore(
           adminApp,
           'get',
           PROJECTS_COLLECTION,
           {
-            statics: { Timestamp: admin.firestore.Timestamp } as any,
+            statics: { Timestamp: adminApp.firestore.Timestamp } as any,
             where: [
               'dateField',
               '==',
-              admin.firestore.Timestamp.fromDate(currentDate),
+              adminApp.firestore.Timestamp.fromDate(currentDate),
             ],
           },
         );
@@ -156,22 +157,26 @@ describe('tasks', () => {
         const pastDate = new Date();
         pastDate.setDate(pastDate.getDate() - 2);
         const fieldName = 'anotherField';
-        await projectsFirestoreRef
-          .doc(projectId)
-          .set({ [fieldName]: admin.firestore.Timestamp.fromDate(pastDate) });
+        await projectsFirestoreRef.doc(projectId).set({
+          [fieldName]: adminApp.firestore.Timestamp.fromDate(pastDate),
+        });
         const result = await tasks.callFirestore(
           adminApp,
           'get',
           PROJECTS_COLLECTION,
           {
-            statics: { Timestamp: admin.firestore.Timestamp } as any,
+            statics: { Timestamp: adminApp.firestore.Timestamp } as any,
             where: [
               [
                 fieldName,
                 '>=',
-                admin.firestore.Timestamp.fromDate(new Date('1/1/21')),
+                adminApp.firestore.Timestamp.fromDate(new Date('1/1/21')),
               ],
-              [fieldName, '<=', admin.firestore.Timestamp.fromDate(new Date())],
+              [
+                fieldName,
+                '<=',
+                adminApp.firestore.Timestamp.fromDate(new Date()),
+              ],
             ],
           },
         );
@@ -345,7 +350,7 @@ describe('tasks', () => {
         };
         beforeEach(() => {
           vi.spyOn(
-            admin.firestore.FieldValue,
+            adminApp.firestore.FieldValue,
             'serverTimestamp',
           ).mockReturnValue(correctTimestamp as any);
         });
@@ -365,7 +370,7 @@ describe('tasks', () => {
             adminApp,
             'set',
             PROJECT_PATH,
-            { statics: admin.firestore },
+            { statics: adminApp.firestore },
             { timeProperty: stringifiedServerTimestamp },
           );
 
@@ -387,7 +392,7 @@ describe('tasks', () => {
             adminApp,
             'set',
             PROJECT_PATH,
-            { statics: admin.firestore },
+            { statics: adminApp.firestore },
             { timeArrProperty: [stringifiedServerTimestamp] },
           );
 
@@ -409,7 +414,7 @@ describe('tasks', () => {
             adminApp,
             'set',
             PROJECT_PATH,
-            { statics: admin.firestore },
+            { statics: adminApp.firestore },
             { time: { nested: stringifiedServerTimestamp } },
           );
 
@@ -428,7 +433,7 @@ describe('tasks', () => {
             adminApp,
             'set',
             PROJECT_PATH,
-            { statics: admin.firestore },
+            { statics: adminApp.firestore },
             {
               geoPointProperty: { latitude: 32.323443, longitude: 122.3954238 },
             },
@@ -436,7 +441,7 @@ describe('tasks', () => {
 
           const resultSnap = await projectFirestoreRef.get();
           expect(resultSnap.get('geoPointProperty')).toBeInstanceOf(
-            admin.firestore.GeoPoint,
+            adminApp.firestore.GeoPoint,
           );
         });
       });
@@ -474,14 +479,14 @@ describe('tasks', () => {
           adminApp,
           'update',
           PROJECT_PATH,
-          { statics: admin.firestore, merge: true },
+          { statics: adminApp.firestore, merge: true },
           { some: legacyStringifiedFieldDelete },
         );
         await tasks.callFirestore(
           adminApp,
           'update',
           PROJECT_PATH,
-          { statics: admin.firestore, merge: true },
+          { statics: adminApp.firestore, merge: true },
           { another: stringifiedFieldDelete },
         );
         const resultSnap = await projectFirestoreRef.get();
@@ -509,7 +514,7 @@ describe('tasks', () => {
           adminApp,
           'set',
           PROJECT_PATH,
-          { statics: admin.firestore, merge: true },
+          { statics: adminApp.firestore, merge: true },
           { top: { second: { some: stringifiedFieldDelete } } },
         );
         const resultSnap = await projectFirestoreRef.get();
@@ -527,7 +532,7 @@ describe('tasks', () => {
         };
         beforeEach(() => {
           vi.spyOn(
-            admin.firestore.FieldValue,
+            adminApp.firestore.FieldValue,
             'serverTimestamp',
           ).mockReturnValue(correctTimestamp as any);
         });
@@ -547,7 +552,7 @@ describe('tasks', () => {
             adminApp,
             'update',
             PROJECT_PATH,
-            { statics: admin.firestore },
+            { statics: adminApp.firestore },
             { timeProperty: stringifiedServerTimestamp },
           );
 
@@ -575,7 +580,7 @@ describe('tasks', () => {
             adminApp,
             'update',
             PROJECT_PATH,
-            { statics: admin.firestore },
+            { statics: adminApp.firestore },
             {
               time: {
                 nested: stringifiedServerTimestamp,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "outDir": "lib",
     "rootDir": "./src",
     "importHelpers": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
   },
   "typeRoots": ["./types", "./node_modules/@types"],
   "include": ["src/**/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,13 +757,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/app-check-interop-types@npm:0.3.3":
-  version: 0.3.3
-  resolution: "@firebase/app-check-interop-types@npm:0.3.3"
-  checksum: 10c0/4a887ef5e30ee1a407b569603c433a9f21244d50a19d97a5f1f17d8f5caea83096852b39e67d599f3238f1f7e2a369b02d184a184986a649ed1f8fed12fbd6be
-  languageName: node
-  linkType: hard
-
 "@firebase/app-check-interop-types@npm:0.3.4":
   version: 0.3.4
   resolution: "@firebase/app-check-interop-types@npm:0.3.4"
@@ -805,13 +798,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/app-types@npm:0.9.3":
-  version: 0.9.3
-  resolution: "@firebase/app-types@npm:0.9.3"
-  checksum: 10c0/02ec9a26c10b9bbb2a1e5b9ae0552b5325b40066e3c23be089ceae53414a1505f2ab716ae1098652a0a0c9992ba322c05371a9b2a837cccfae309788372a72e0
-  languageName: node
-  linkType: hard
-
 "@firebase/app-types@npm:0.9.5":
   version: 0.9.5
   resolution: "@firebase/app-types@npm:0.9.5"
@@ -846,13 +832,6 @@ __metadata:
   peerDependencies:
     "@firebase/app-compat": 0.x
   checksum: 10c0/3e0c6a464bf52926271cccafe5073a548da3d3a142be63e25fbf06dcd67dc6cb697c5562d73fbd64727e917271f285bc18a048876366051b2ea1edfaac0ef985
-  languageName: node
-  linkType: hard
-
-"@firebase/auth-interop-types@npm:0.2.4":
-  version: 0.2.4
-  resolution: "@firebase/auth-interop-types@npm:0.2.4"
-  checksum: 10c0/ff833bcbb472992c6061847309e338dac736c616522c5fd808526d6dc13b9788458a8c9677d91c33c1288ee38f42896c2b4b8fe10ee74f1569d11f3f3c4f53b5
   languageName: node
   linkType: hard
 
@@ -891,16 +870,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/component@npm:0.7.2":
-  version: 0.7.2
-  resolution: "@firebase/component@npm:0.7.2"
-  dependencies:
-    "@firebase/util": "npm:1.15.0"
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/495d76833116732dd2cf9b26149929f012530f486367e1979c67756996af32ce6704e9435cbf5e0849c512d16e878d6757eaff09d36e0cb31b38c1bc12040e5b
-  languageName: node
-  linkType: hard
-
 "@firebase/component@npm:0.7.3":
   version: 0.7.3
   resolution: "@firebase/component@npm:0.7.3"
@@ -926,7 +895,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/database-compat@npm:2.1.4":
+"@firebase/database-compat@npm:2.1.4, @firebase/database-compat@npm:^2.1.4":
   version: 2.1.4
   resolution: "@firebase/database-compat@npm:2.1.4"
   dependencies:
@@ -940,52 +909,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/database-compat@npm:^2.0.0":
-  version: 2.1.2
-  resolution: "@firebase/database-compat@npm:2.1.2"
-  dependencies:
-    "@firebase/component": "npm:0.7.2"
-    "@firebase/database": "npm:1.1.2"
-    "@firebase/database-types": "npm:1.0.18"
-    "@firebase/logger": "npm:0.5.0"
-    "@firebase/util": "npm:1.15.0"
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/2a7046617f495bd4762f99f61ef901b3b148cdfbc22ed16c708db88b518d87d62b5fb687cbe0cc74ce632346581fb727d0a98d5138b76c61d10c7a338df453e3
-  languageName: node
-  linkType: hard
-
-"@firebase/database-types@npm:1.0.18, @firebase/database-types@npm:^1.0.6":
-  version: 1.0.18
-  resolution: "@firebase/database-types@npm:1.0.18"
-  dependencies:
-    "@firebase/app-types": "npm:0.9.3"
-    "@firebase/util": "npm:1.15.0"
-  checksum: 10c0/196a3778a44294cfce91bcd3f69072fcbbab106b50c55781d8a14a8637c2799f7215b22fb2a8c9779964b55a3ed55af22a878ef944636d2fbbd68176ee3c71ab
-  languageName: node
-  linkType: hard
-
-"@firebase/database-types@npm:1.0.20":
+"@firebase/database-types@npm:1.0.20, @firebase/database-types@npm:^1.0.20":
   version: 1.0.20
   resolution: "@firebase/database-types@npm:1.0.20"
   dependencies:
     "@firebase/app-types": "npm:0.9.5"
     "@firebase/util": "npm:1.15.1"
   checksum: 10c0/bc2848ded44b3bbf0352cd9f5580190b4e82b83c99618e0cf76a84a68850a4cf87954b1d9fff134ae4d930be79188eb5e7e34e3007e25576d630f1c83a7ace0f
-  languageName: node
-  linkType: hard
-
-"@firebase/database@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@firebase/database@npm:1.1.2"
-  dependencies:
-    "@firebase/app-check-interop-types": "npm:0.3.3"
-    "@firebase/auth-interop-types": "npm:0.2.4"
-    "@firebase/component": "npm:0.7.2"
-    "@firebase/logger": "npm:0.5.0"
-    "@firebase/util": "npm:1.15.0"
-    faye-websocket: "npm:0.11.4"
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/f6eb1d262feff5aa8402ee449bb41ef48a0e43e943120f186735feaf79a5f8f53ddcfc36e982717a359ac96d8bd3131e050b0251d1d433fa19b229b8a6d2fe77
   languageName: node
   linkType: hard
 
@@ -1119,15 +1049,6 @@ __metadata:
   peerDependencies:
     "@firebase/app": 0.x
   checksum: 10c0/c8c0f5135b81254f85d68cee80561abad916238220802a5c5734dbd76e52742b91a61767aa1a14e0363e5aa6fd21c67aad47a7117f9c99a2902ef01af8c86739
-  languageName: node
-  linkType: hard
-
-"@firebase/logger@npm:0.5.0":
-  version: 0.5.0
-  resolution: "@firebase/logger@npm:0.5.0"
-  dependencies:
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/c9bfa2381b89b7dc674aeaaa497b73076041c56d6d65cbebcb3227c264b737394528d7f94658a7acb169bd14793cfcb33865207b2d32a7a6ac858e68c5c61b7e
   languageName: node
   linkType: hard
 
@@ -1301,15 +1222,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/util@npm:1.15.0":
-  version: 1.15.0
-  resolution: "@firebase/util@npm:1.15.0"
-  dependencies:
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/d64dc500f96764c545269caf5affff1f2b6b7f600d301c669395f0c827b66055645e3e8e274ce67abb5f765347a957d6cabab079a3a569a661f70064cb755cbe
-  languageName: node
-  linkType: hard
-
 "@firebase/util@npm:1.15.1":
   version: 1.15.1
   resolution: "@firebase/util@npm:1.15.1"
@@ -1345,16 +1257,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google-cloud/firestore@npm:^7.11.0":
-  version: 7.11.6
-  resolution: "@google-cloud/firestore@npm:7.11.6"
+"@google-cloud/firestore@npm:^8.6.0":
+  version: 8.6.0
+  resolution: "@google-cloud/firestore@npm:8.6.0"
   dependencies:
-    "@opentelemetry/api": "npm:^1.3.0"
-    fast-deep-equal: "npm:^3.1.1"
+    "@opentelemetry/api": "npm:^1.9.0"
+    fast-deep-equal: "npm:^3.1.3"
     functional-red-black-tree: "npm:^1.0.1"
-    google-gax: "npm:^4.3.3"
-    protobufjs: "npm:^7.2.6"
-  checksum: 10c0/db47b0abb30ac2c141522fa1de7906d7c9e79bfd1e55aaae4c2439ffb2a2f542a81f803781b5aa213eb0070a8eec1d1baeb5c20d70720a6c05d78ae967490d82
+    google-gax: "npm:^5.0.1"
+    protobufjs: "npm:^7.5.3"
+  checksum: 10c0/0d66b3c4469ff919504925054f6169d4761968b9f932aa373c0dbee642390db9dcc4060b1586494ea6f681c150b5db2198d4eeddf88ea1f34afb51c2f5f1f38b
   languageName: node
   linkType: hard
 
@@ -1467,7 +1379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grpc/grpc-js@npm:^1.10.9, @grpc/grpc-js@npm:^1.12.6":
+"@grpc/grpc-js@npm:^1.12.6":
   version: 1.14.3
   resolution: "@grpc/grpc-js@npm:1.14.3"
   dependencies:
@@ -1487,7 +1399,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grpc/proto-loader@npm:^0.7.13, @grpc/proto-loader@npm:^0.7.8":
+"@grpc/proto-loader@npm:^0.7.8":
   version: 0.7.15
   resolution: "@grpc/proto-loader@npm:0.7.15"
   dependencies:
@@ -1926,7 +1838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:~1.9.0":
+"@opentelemetry/api@npm:^1.9.0, @opentelemetry/api@npm:~1.9.0":
   version: 1.9.1
   resolution: "@opentelemetry/api@npm:1.9.1"
   checksum: 10c0/c608485fc8b5a91e1f7e05e843b45b509307456b31cd2ad365933d90813e40ebfedf179f1451c762037e82d7c76aa8500e95d2da3609f640a1206cde5322cd14
@@ -2020,10 +1932,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/codegen@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@protobufjs/codegen@npm:2.0.5"
+  checksum: 10c0/1b8a2ae56ee60a56e9d205cd4b6072a1503c5069b8ebb905710f974ff0098a0d0700641c137e0a8d98dedf14423156a106a9433695cbf52574810f55000fdcab
+  languageName: node
+  linkType: hard
+
 "@protobufjs/eventemitter@npm:^1.1.0":
   version: 1.1.0
   resolution: "@protobufjs/eventemitter@npm:1.1.0"
   checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
   languageName: node
   linkType: hard
 
@@ -2034,6 +1960,15 @@ __metadata:
     "@protobufjs/aspromise": "npm:^1.1.1"
     "@protobufjs/inquire": "npm:^1.1.0"
   checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+  checksum: 10c0/a497ff5433854e8577f0427983ea39b9113b49a8120f94515291d763327061d2c3013e60e24ea436d091dafae01a0f6eb1867e3b1616045d96a31d8b3c646ed4
   languageName: node
   linkType: hard
 
@@ -2048,6 +1983,13 @@ __metadata:
   version: 1.1.0
   resolution: "@protobufjs/inquire@npm:1.1.0"
   checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/inquire@npm:1.1.2"
+  checksum: 10c0/af69597818a14cac6a00a74cd5b3fb85aa96658b9dbbae73e6d907cb154ebf470953a8c537b3e6095a43de565ec4e6c5b40227c72f4a7d762d34fbec7ac179e7
   languageName: node
   linkType: hard
 
@@ -2069,6 +2011,13 @@ __metadata:
   version: 1.1.0
   resolution: "@protobufjs/utf8@npm:1.1.0"
   checksum: 10c0/a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/utf8@npm:1.1.1"
+  checksum: 10c0/641fc145f00626405e8984b6e90b9edcbcc072ffc82d0647ca3176e09c730b2d022f988e65f011a7a17e2e4d77cde7733643aa10d8ac2bfa30f134dbcad553fd
   languageName: node
   linkType: hard
 
@@ -2369,13 +2318,6 @@ __metadata:
     "@types/ms": "npm:*"
     "@types/node": "npm:*"
   checksum: 10c0/0688ac8fb75f809201cb7e18a12b9d80ce539cb9dd27e1b01e11807cb1a337059e899b8ee3abc3f2c9417f02e363a3069d9eab9ef9724b1da1f0e10713514f94
-  languageName: node
-  linkType: hard
-
-"@types/long@npm:^4.0.0":
-  version: 4.0.2
-  resolution: "@types/long@npm:4.0.2"
-  checksum: 10c0/42ec66ade1f72ff9d143c5a519a65efc7c1c77be7b1ac5455c530ae9acd87baba065542f8847522af2e3ace2cc999f3ad464ef86e6b7352eece34daf88f8c924
   languageName: node
   linkType: hard
 
@@ -4157,7 +4099,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:4.1.8"
     cypress: "npm:15.17.0"
     firebase: "npm:12.14.0"
-    firebase-admin: "npm:13.10.0"
+    firebase-admin: "npm:14.0.0"
     firebase-tools: "npm:15.20.0"
     husky: "npm:9.1.7"
     lint-staged: "npm:17.0.7"
@@ -4396,7 +4338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexify@npm:^4.0.0, duplexify@npm:^4.1.3":
+"duplexify@npm:^4.1.3":
   version: 4.1.3
   resolution: "duplexify@npm:4.1.3"
   dependencies:
@@ -5177,26 +5119,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"firebase-admin@npm:13.10.0":
-  version: 13.10.0
-  resolution: "firebase-admin@npm:13.10.0"
+"firebase-admin@npm:14.0.0":
+  version: 14.0.0
+  resolution: "firebase-admin@npm:14.0.0"
   dependencies:
     "@fastify/busboy": "npm:^3.0.0"
-    "@firebase/database-compat": "npm:^2.0.0"
-    "@firebase/database-types": "npm:^1.0.6"
-    "@google-cloud/firestore": "npm:^7.11.0"
+    "@firebase/database-compat": "npm:^2.1.4"
+    "@firebase/database-types": "npm:^1.0.20"
+    "@google-cloud/firestore": "npm:^8.6.0"
     "@google-cloud/storage": "npm:^7.19.0"
     farmhash-modern: "npm:^1.1.0"
     fast-deep-equal: "npm:^3.1.1"
-    google-auth-library: "npm:^10.6.1"
+    google-auth-library: "npm:^10.6.2"
     jsonwebtoken: "npm:^9.0.0"
-    jwks-rsa: "npm:^3.1.0"
+    jwks-rsa: "npm:^4.0.1"
   dependenciesMeta:
     "@google-cloud/firestore":
       optional: true
     "@google-cloud/storage":
       optional: true
-  checksum: 10c0/a647d91f05a644931ec27c217ebf2143841153f220b041ee97fd64bf402c08552f604112694c2597135fd84275144c2f19fc92920f8e01cb0caef4240b1e4974
+  checksum: 10c0/46588d9d107779c1ca06b6fc99c77265ea2e20cb9975128c4f1ad627d860d13d88afb4fb8c10a47482643f43d287db4e59e5d36a91a26dc070c14e59c0ac8094
   languageName: node
   linkType: hard
 
@@ -5474,6 +5416,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gaxios@npm:7.1.3":
+  version: 7.1.3
+  resolution: "gaxios@npm:7.1.3"
+  dependencies:
+    extend: "npm:^3.0.2"
+    https-proxy-agent: "npm:^7.0.1"
+    node-fetch: "npm:^3.3.2"
+    rimraf: "npm:^5.0.1"
+  checksum: 10c0/a4a1cdf9a392c0c22e9734a40dca5a77a2903f505b939a50f1e68e312458b1289b7993d2f72d011426e89657cae77a3aa9fc62fb140e8ba90a1faa31fdbde4d2
+  languageName: node
+  linkType: hard
+
 "gaxios@npm:^6.0.0, gaxios@npm:^6.0.2, gaxios@npm:^6.1.1, gaxios@npm:^6.7.0":
   version: 6.7.1
   resolution: "gaxios@npm:6.7.1"
@@ -5517,6 +5471,17 @@ __metadata:
     google-logging-utils: "npm:^0.0.2"
     json-bigint: "npm:^1.0.0"
   checksum: 10c0/71f6ad4800aa622c246ceec3955014c0c78cdcfe025971f9558b9379f4019f5e65772763428ee8c3244fa81b8631977316eaa71a823493f82e5c44d7259ffac8
+  languageName: node
+  linkType: hard
+
+"gcp-metadata@npm:^8.0.0":
+  version: 8.1.3
+  resolution: "gcp-metadata@npm:8.1.3"
+  dependencies:
+    gaxios: "npm:7.1.3"
+    google-logging-utils: "npm:1.1.3"
+    json-bigint: "npm:^1.0.0"
+  checksum: 10c0/42a4f8a42084f66136891a256a7acc89eefcb07ec55509b39f3f99ecf1fed9ed8216bb1990722192eaea2bbf3f96e23631a81d68cc166c5bac90a540fbf892c8
   languageName: node
   linkType: hard
 
@@ -5692,6 +5657,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-auth-library@npm:10.5.0":
+  version: 10.5.0
+  resolution: "google-auth-library@npm:10.5.0"
+  dependencies:
+    base64-js: "npm:^1.3.0"
+    ecdsa-sig-formatter: "npm:^1.0.11"
+    gaxios: "npm:^7.0.0"
+    gcp-metadata: "npm:^8.0.0"
+    google-logging-utils: "npm:^1.0.0"
+    gtoken: "npm:^8.0.0"
+    jws: "npm:^4.0.0"
+  checksum: 10c0/49d3931d20b1f4a4d075216bf5518e2b3396dcf441a8f1952611cf3b6080afb1261c3d32009609047ee4a1cc545269a74b4957e6bba9cce840581df309c4b145
+  languageName: node
+  linkType: hard
+
 "google-auth-library@npm:^10.1.0, google-auth-library@npm:^10.5.0, google-auth-library@npm:^10.6.1":
   version: 10.6.2
   resolution: "google-auth-library@npm:10.6.2"
@@ -5706,7 +5686,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"google-auth-library@npm:^9.11.0, google-auth-library@npm:^9.3.0, google-auth-library@npm:^9.6.3":
+"google-auth-library@npm:^10.6.2":
+  version: 10.7.0
+  resolution: "google-auth-library@npm:10.7.0"
+  dependencies:
+    base64-js: "npm:^1.3.0"
+    ecdsa-sig-formatter: "npm:^1.0.11"
+    gaxios: "npm:^7.1.4"
+    gcp-metadata: "npm:8.1.2"
+    google-logging-utils: "npm:1.1.3"
+    jws: "npm:^4.0.0"
+  checksum: 10c0/e8827ff84a69bbd6573229d8245d8fbb8870304e255c213571541d039c33764a6f4a8d773c002a16d6d75e35b9a596310b5c6f8e25b189a02eb4cebd6f022321
+  languageName: node
+  linkType: hard
+
+"google-auth-library@npm:^9.11.0, google-auth-library@npm:^9.6.3":
   version: 9.15.1
   resolution: "google-auth-library@npm:9.15.1"
   dependencies:
@@ -5720,23 +5714,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"google-gax@npm:^4.3.3":
-  version: 4.6.1
-  resolution: "google-gax@npm:4.6.1"
+"google-gax@npm:^5.0.1":
+  version: 5.0.7
+  resolution: "google-gax@npm:5.0.7"
   dependencies:
-    "@grpc/grpc-js": "npm:^1.10.9"
-    "@grpc/proto-loader": "npm:^0.7.13"
-    "@types/long": "npm:^4.0.0"
-    abort-controller: "npm:^3.0.0"
-    duplexify: "npm:^4.0.0"
-    google-auth-library: "npm:^9.3.0"
-    node-fetch: "npm:^2.7.0"
+    "@grpc/grpc-js": "npm:^1.12.6"
+    "@grpc/proto-loader": "npm:^0.8.0"
+    duplexify: "npm:^4.1.3"
+    google-auth-library: "npm:10.5.0"
+    google-logging-utils: "npm:1.1.3"
+    node-fetch: "npm:^3.3.2"
     object-hash: "npm:^3.0.0"
-    proto3-json-serializer: "npm:^2.0.2"
-    protobufjs: "npm:^7.3.2"
-    retry-request: "npm:^7.0.0"
-    uuid: "npm:^9.0.1"
-  checksum: 10c0/740e47beb1def74d3e0074f8582fd919423f6c261b8cfa1c6a6c1c5bf9d8b92a11f1afe07eb1eea2fda7f4b6603c836f9427ed3cfa4c04ae97eb00db7c291400
+    proto3-json-serializer: "npm:3.0.4"
+    protobufjs: "npm:^7.5.4"
+    retry-request: "npm:^8.0.2"
+    rimraf: "npm:^5.0.1"
+  checksum: 10c0/23589773ed578b96e31a5a8c2c327237854db3d1109f1e7dd2355c73ff2cd93d63c17b2505d237db8330b283c85440120b57db0f64dbcff76a3076ffc49ec6ec
   languageName: node
   linkType: hard
 
@@ -5814,6 +5807,16 @@ __metadata:
     gaxios: "npm:^6.0.0"
     jws: "npm:^4.0.0"
   checksum: 10c0/0a3dcacb1a3c4578abe1ee01c7d0bf20bffe8ded3ee73fc58885d53c00f6eb43b4e1372ff179f0da3ed5cfebd5b7c6ab8ae2776f1787e90d943691b4fe57c716
+  languageName: node
+  linkType: hard
+
+"gtoken@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "gtoken@npm:8.0.0"
+  dependencies:
+    gaxios: "npm:^7.0.0"
+    jws: "npm:^4.0.0"
+  checksum: 10c0/058538e5bbe081d30ada5f1fd34d3a8194357c2e6ecbf7c8a98daeefbf13f7e06c15649c7dace6a1d4cc3bc6dc5483bd484d6d7adc5852021896d7c05c439f37
   languageName: node
   linkType: hard
 
@@ -6420,13 +6423,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jose@npm:^4.15.4":
-  version: 4.15.9
-  resolution: "jose@npm:4.15.9"
-  checksum: 10c0/4ed4ddf4a029db04bd167f2215f65d7245e4dc5f36d7ac3c0126aab38d66309a9e692f52df88975d99429e357e5fd8bab340ff20baab544d17684dd1d940a0f4
-  languageName: node
-  linkType: hard
-
 "jose@npm:^6.1.3":
   version: 6.2.2
   resolution: "jose@npm:6.2.2"
@@ -6592,16 +6588,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jwks-rsa@npm:^3.1.0":
-  version: 3.2.2
-  resolution: "jwks-rsa@npm:3.2.2"
+"jwks-rsa@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jwks-rsa@npm:4.0.1"
   dependencies:
     "@types/jsonwebtoken": "npm:^9.0.4"
     debug: "npm:^4.3.4"
-    jose: "npm:^4.15.4"
+    jose: "npm:^6.1.3"
     limiter: "npm:^1.1.5"
-    lru-memoizer: "npm:^2.2.0"
-  checksum: 10c0/a619ee0c5b342e1c9edcd69086d7beb86e3ef1dcce5b8aeb3ac6d0c0014309c90f00e5e7b0ce8143832628244fec8cdff51ecc38a5c3a95a4fcd810d60e79b1a
+    lru-memoizer: "npm:^3.0.0"
+  checksum: 10c0/aeca4b1de959707002150556f4f08ed3677fe9dd12bd0be0aa01220a86b88867357c7d2241f4975de9f53125d41cc3f5e4c5e929a8922f257b61634b208d7e3c
   languageName: node
   linkType: hard
 
@@ -6984,19 +6980,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^5.0.0":
+"long@npm:^5.0.0, long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:6.0.0":
-  version: 6.0.0
-  resolution: "lru-cache@npm:6.0.0"
-  dependencies:
-    yallist: "npm:^4.0.0"
-  checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
   languageName: node
   linkType: hard
 
@@ -7014,6 +7001,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.1":
+  version: 11.5.1
+  resolution: "lru-cache@npm:11.5.1"
+  checksum: 10c0/7b341cea79a8efe9c6a6f20c8757a77eca5b25d7ff983ccf4e11e547b81f6787824baa1c84705251dff84ab4ffac85717ac354b9d02e465f86a9f8b166409979
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^7.14.1":
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
@@ -7021,13 +7015,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-memoizer@npm:^2.2.0":
-  version: 2.3.0
-  resolution: "lru-memoizer@npm:2.3.0"
+"lru-memoizer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "lru-memoizer@npm:3.0.0"
   dependencies:
     lodash.clonedeep: "npm:^4.5.0"
-    lru-cache: "npm:6.0.0"
-  checksum: 10c0/13cf6bc9ff74cdb167078dbb66d4cf43adc802495da8f56097e6f388b4d7ccb91668beb809bdbc55b62d016c138d7c19a18c5883a2fdbcc7f508ad8a23ec7c65
+    lru-cache: "npm:^11.0.1"
+  checksum: 10c0/d4d1abedd56a79da6416e0c1ae736c6bc084155d45efe427182d4a8318a1054c5fbd9bba154e6dfe8a8b7de7630392186b81faa84f15746eb5459dc0567f181c
   languageName: node
   linkType: hard
 
@@ -7545,7 +7539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7, node-fetch@npm:^2.6.9, node-fetch@npm:^2.7.0":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7, node-fetch@npm:^2.6.9":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -8177,16 +8171,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proto3-json-serializer@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "proto3-json-serializer@npm:2.0.2"
-  dependencies:
-    protobufjs: "npm:^7.2.5"
-  checksum: 10c0/802e6a34f6ebf07007b186768f1985494bdfa6dd92e14c89d10cda6c4cc14df707ad59b75054a17a582f481db12c7663d25f91f505d2a85d7d4174eb5d798628
-  languageName: node
-  linkType: hard
-
-"proto3-json-serializer@npm:^3.0.0":
+"proto3-json-serializer@npm:3.0.4, proto3-json-serializer@npm:^3.0.0":
   version: 3.0.4
   resolution: "proto3-json-serializer@npm:3.0.4"
   dependencies:
@@ -8195,7 +8180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
+"protobufjs@npm:^7.2.5, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
   version: 7.5.4
   resolution: "protobufjs@npm:7.5.4"
   dependencies:
@@ -8212,6 +8197,26 @@ __metadata:
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
   checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.5.4":
+  version: 7.6.3
+  resolution: "protobufjs@npm:7.6.3"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.5"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
+    "@protobufjs/fetch": "npm:^1.1.1"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.2"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.1"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.3.2"
+  checksum: 10c0/e1132b1ff82684280041550d720398568763ff40928def03e8bb409eaed6edd222e63372e3f52d7c19e5a8e9975333480e26950759086eb5a1f5b5c118da7bf8
   languageName: node
   linkType: hard
 
@@ -8531,6 +8536,16 @@ __metadata:
     extend: "npm:^3.0.2"
     teeny-request: "npm:^10.0.0"
   checksum: 10c0/e0b44950d69fe8f51d4e808650cd0d06383cd711adcc71e7764b28b2f10a9ac3b2209f0c9ac0547df0745031810a259730b9d13b0070d69df9806c37432456a9
+  languageName: node
+  linkType: hard
+
+"retry-request@npm:^8.0.2":
+  version: 8.0.3
+  resolution: "retry-request@npm:8.0.3"
+  dependencies:
+    extend: "npm:^3.0.2"
+    teeny-request: "npm:^10.0.0"
+  checksum: 10c0/07853e505dd61c84bfa5962979303dc806d8a05605cf0906b5157aaa73e4db3d39c918f6db81769c043582f4bddc245adae19c794cff39c7290e6ed46cb4b284
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds support for **firebase-admin v14**, which removed the legacy namespaced API (`admin.firestore()`, `admin.auth()`, `admin.credential`, `admin.apps`) that the plugin used to reach services on the consumer-provided instance. Without this change the plugin crashes for any consumer on v14.

Consumers don't change anything — they keep passing their `firebase-admin` module to `plugin()` as before, on any version from 11 through 14.

### How

- **Adapter in the plugin (runtime)**: `plugin.ts` detects a modular module via `isModularAdmin` (has `getApps`, lacks `.firestore`) and wraps it with `adaptModularAdmin`, which recreates the legacy shape: `apps`/`initializeApp`/`credential` delegate to the module's own exports (v14 still exports `initializeApp`, `getApps`, `cert`, `applicationDefault` from the root), while `firestore()`/`auth()`/`database()` are built from lazily-required `firebase-admin/*` subpath entry points (a peer dependency, loaded only in the node context). Legacy modules (v11–13) pass through untouched.
- **Browser safety**: the `firebase-admin/*` subpaths are stubbed in `package.json`'s `browser` field so the lazy requires never reach browser bundles of the support file. Size budget unaffected: both exports at 8.8 kB of the 9 kB limit.
- **Types**: type-only imports migrated from the removed root namespaces to the modular subpaths (`firebase-admin/app`, `/auth`, `/database`, `/firestore`). These subpaths exist since v11, so the `>=11.0.0` peer range is unchanged. The `app.App['firestore']` statics typing became an explicit `FirestoreStatics` type. `"types": ["node"]` was added to tsconfig — node globals (`process`, `console`) previously resolved only through firebase-admin v13's type references.
- **Tests**: `tasks.spec.ts` (the emulator integration suite) now exercises the real v14 modular API through the adapter — the same shape `plugin.ts` hands to tasks. New `plugin.spec.ts` test covers adapter detection/initialization. 171 tests passing.

### Versioning note

This is a `feat` (minor release): v14 consumers gain support, v11–13 consumers are unaffected, and the public API is unchanged. No `engines` constraint was added — firebase-admin v14's own `node >=22` requirement applies only to consumers who choose v14.

### Verification

- `yarn test` against the emulators: 6 files, **171 tests passing** (tasks suite runs through the v14 adapter)
- `yarn build`, `yarn lint`, `yarn format:check`: clean
- `yarn size`: 8.8 kB / 9 kB on both exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)